### PR TITLE
Update to Graql and Concept behaviours

### DIFF
--- a/concept/rule/rule.feature
+++ b/concept/rule/rule.feature
@@ -15,4 +15,5 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Rule

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Attribute
 
   Background:

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -287,6 +287,20 @@ Feature: Concept Attribute
     When $x = attribute(birth-date) as(datetime) get: 1990-01-01 11:22:33
     Then attribute $x is null: true
 
+  Scenario: Attribute with value type double is assignable and retrievable from a 'long' value
+    When $x = attribute(score) as(double) put: 123
+    Then attribute $x is null: false
+    Then attribute $x has type: score
+    Then attribute $x has value type: double
+    Then attribute $x has double value: 123
+    When transaction commits
+    When session opens transaction of type: read
+    When $x = attribute(score) as(double) get: 123
+    Then attribute $x is null: false
+    Then attribute $x has type: score
+    Then attribute $x has value type: double
+    Then attribute $x has double value: 123
+
   Scenario: Attribute with value type boolean can be owned
 
   Scenario: Attribute with value type long can be owned

--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Entity
 
   Background:

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Relation
 
   Background:

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -660,3 +660,15 @@ Feature: Concept Attribute Type
       | person |
     Then attribute(email) get key owners do not contain:
       | company |
+
+  Scenario: Attribute types with value type string can unset their regular expression
+    When put attribute type: email, with value type: string
+    When attribute(email) as(string) set regex: \S+@\S+\.\S+
+    Then attribute(email) as(string) get regex: \S+@\S+\.\S+
+    When transaction commits
+    When session opens transaction of type: write
+    Then attribute(email) as(string) unset regex
+    Then attribute(email) as(string) does not have any regex
+    Then transaction commits
+    When session opens transaction of type: read
+    Then attribute(email) as(string) does not have any regex

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Attribute Type
 
   Background:

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Entity Type
 
   Background:

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -930,6 +930,19 @@ Feature: Concept Entity Type
     Then relation(marriage) get role(wife) get players do not contain:
       | person |
 
+  Scenario: Entity types can unset playing role types that they don't actually play, which is a no-op
+    When put relation type: marriage
+    When relation(marriage) set relates role: husband
+    When relation(marriage) set relates role: wife
+    When put entity type: person
+    When entity(person) set plays role: marriage:wife
+    Then entity(person) get playing roles do not contain:
+      | marriage:husband |
+    Then entity(person) unset plays role: marriage:husband
+    Then entity(person) get playing roles do not contain:
+      | marriage:husband |
+    Then transaction commits
+
   Scenario: Entity types can inherit playing role types
     When put relation type: parentship
     When relation(parentship) set relates role: parent

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -111,6 +111,28 @@ Feature: Concept Relation Type and Role Type
     When session opens transaction of type: write
     Then delete relation type: marriage; throws exception
 
+  Scenario: Role types that have instances cannot be deleted
+    When put relation type: marriage
+    When relation(marriage) set relates role: wife
+    When relation(marriage) set relates role: husband
+    When put entity type: person
+    When entity(person) set plays role: marriage:wife
+    When transaction commits
+    When connection close all sessions
+    When connection open data session for database: grakn
+    When session opens transaction of type: write
+    When $m = relation(marriage) create new instance
+    When $a = entity(person) create new instance
+    When relation $m add player for role(wife): $a
+    When transaction commits
+    When connection close all sessions
+    When connection open schema session for database: grakn
+    When session opens transaction of type: write
+    Then relation(marriage) unset related role: wife; throws exception
+    When session opens transaction of type: write
+    Then relation(marriage) unset related role: husband
+    Then transaction commits
+
   Scenario: Relation and role types can change labels
     When put relation type: parentship
     When relation(parentship) set relates role: parent

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Relation Type and Role Type
 
   Background:

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -192,6 +192,14 @@ Feature: Concept Relation Type and Role Type
     Then relation(parentship) get role(child) is abstract: true
     Then relation(parentship) create new instance; throws exception
 
+  Scenario: Relation types must have at least one role in order to commit, unless they are abstract
+    When put relation type: connection
+    Then transaction commits; throws exception
+    When session opens transaction of type: write
+    When put relation type: connection
+    When relation(connection) set abstract: true
+    Then transaction commits
+
   Scenario: Relation and role types can be subtypes of other relation and role types
     When put relation type: parentship
     When relation(parentship) set relates role: parent

--- a/concept/type/thingtype.feature
+++ b/concept/type/thingtype.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Concept Thing Type
 
   Background:

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Connection Database
 
   Background:

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Connection Session
 
   Background:

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Connection Transaction
 
   Background:

--- a/graql/explanation/language.feature
+++ b/graql/explanation/language.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Graql Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario

--- a/graql/explanation/reasoner.feature
+++ b/graql/explanation/reasoner.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Graql Reasoning Explanation
 
   Only scenarios where there is only one possible resolution path can be tested in this way

--- a/graql/language/compute.feature
+++ b/graql/language/compute.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Compute Query
 
   # This file is retained as a placeholder for future functionality

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Define Query
 
   Background: Open connection and create a simple extensible schema

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -1827,31 +1827,7 @@ Feature: Graql Define Query
     Then the integrity is validated
 
 
-  Scenario: the definition of a rule is not modifiable
-    Given graql define
-      """
-      define
-      nickname sub attribute, value string;
-      person owns nickname;
-      rule robert-has-nickname-bob:
-      when {
-        $p isa person, has name "Robert";
-      } then {
-        $p has nickname "Bob";
-      };
-      """
-    Given the integrity is validated
-    Then graql define; throws exception
-      """
-      define
-      rule robert-has-nickname-bob:
-      when {
-        $p isa person, has name "robert";
-      } then {
-        $p has nickname "bob";
-      };
-      """
-    Then the integrity is validated
+  Scenario: redefining an existing rule updates its definition
 
 
   #############################

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -296,6 +296,17 @@ Feature: Graql Define Query
     Then the integrity is validated
 
 
+  Scenario: a cyclic type hierarchy is not allowed
+    Then graql define; throws exception
+      """
+      define
+      giant sub person;
+      green-giant sub giant;
+      person sub green-giant;
+      """
+    Then the integrity is validated
+
+
   Scenario: defining a playable role is idempotent
     Given graql define
       """
@@ -1590,7 +1601,7 @@ Feature: Graql Define Query
       | PRD |
 
 
-  Scenario: defining a key on a type throws on commit if existing instances don't have that key
+  Scenario: defining a key on a type throws if existing instances don't have that key
     Given graql define
       """
       define
@@ -1613,12 +1624,11 @@ Feature: Graql Define Query
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    When graql define
+    Then graql define; throws exception
       """
       define
       product owns barcode @key;
       """
-    Then transaction commits; throws exception
     Then the integrity is validated
 
 

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -1800,6 +1800,33 @@ Feature: Graql Define Query
       | PER |
 
 
+  Scenario: defining a rule is idempotent
+    Given graql define
+      """
+      define
+      nickname sub attribute, value string;
+      person owns nickname;
+      rule robert-has-nickname-bob:
+      when {
+        $p isa person, has name "Robert";
+      } then {
+        $p has nickname "Bob";
+      };
+      """
+    Given the integrity is validated
+    Then graql define
+      """
+      define
+      rule robert-has-nickname-bob:
+      when {
+        $p isa person, has name "Robert";
+      } then {
+        $p has nickname "Bob";
+      };
+      """
+    Then the integrity is validated
+
+
   Scenario: the definition of a rule is not modifiable
     Given graql define
       """

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Delete Query
 
   Background: Open connection and create a simple extensible schema

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Get Clause
 
   Background: Open connection and create a simple extensible schema

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -2279,10 +2279,11 @@ Feature: Graql Insert Query
       define
 
       vertex sub entity,
-        owns index @key;
+        owns index @key,
+        plays link:coordinate,
+        plays reachable:coordinate;
 
       link sub relation, relates coordinate;
-      vertex plays reachable:coordinate;
 
       reachable sub relation,
         relates coordinate,

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -1379,6 +1379,23 @@ Feature: Graql Insert Query
       | datetime | start-date | "2019-12-26" |
 
 
+  Scenario: when inserting an attribute, the type and value can be specified in two individual statements
+    When get answers of graql insert
+      """
+      insert
+      $x isa age;
+      $x 10;
+      """
+    Then transaction commits
+    When concept identifiers are
+      |     | check | value  |
+      | A10 | value | age:10 |
+    Then uniquely identify answer concepts
+      | x   |
+      | A10 |
+    Then the integrity is validated
+
+
   Scenario: inserting an attribute with no value throws an error
     Then graql insert; throws exception
       """
@@ -1428,14 +1445,15 @@ Feature: Graql Insert Query
 
 
   Scenario: when a type has a key, attempting to insert it without that key throws on commit
-    Then graql insert; throws exception
+    When graql insert
       """
       insert $x isa person;
       """
+    Then transaction commits; throws exception
     Then the integrity is validated
 
 
-  Scenario: inserting two distinct values of the same key on a thing throws on commit
+  Scenario: inserting two distinct values of the same key on a thing throws an error
     Then graql insert; throws exception
       """
       insert $x isa person, has ref 0, has ref 1;
@@ -2170,7 +2188,7 @@ Feature: Graql Insert Query
     Given graql undefine
       """
       undefine
-      employment owns ref @key;
+      employment owns ref;
       """
     Then transaction commits
     Then the integrity is validated
@@ -2375,9 +2393,9 @@ Feature: Graql Insert Query
     Given graql undefine
       """
       undefine
-      person owns ref @key;
-      company owns ref @key;
-      employment owns ref @key;
+      person owns ref;
+      company owns ref;
+      employment owns ref;
       """
     Given transaction commits
     Given the integrity is validated
@@ -2484,7 +2502,7 @@ Feature: Graql Insert Query
     Given session opens transaction of type: write
     Given graql undefine
       """
-      undefine person owns ref @key;
+      undefine person owns ref;
       """
     Given transaction commits
     Given the integrity is validated

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Insert Query
 
   Background: Open connection and create a simple extensible schema

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Match Query
 
   Background: Open connection and create a simple extensible schema

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Graql Rule Validation
 
   Background: Initialise a session and transaction for each scenario

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -885,6 +885,28 @@ Feature: Graql Undefine Query
       | EMP |
 
 
+  Scenario: removing a playable role throws an error if it is played by existing instances
+    Given connection close all sessions
+    Given connection open data session for database: grakn
+    Given session opens transaction of type: write
+    Given graql insert
+      """
+      insert
+      $p isa person, has email "ganesh@grakn.ai";
+      $r (employee: $p) isa employment;
+      """
+    Given transaction commits
+    Given the integrity is validated
+    Given connection close all sessions
+    Given connection open schema session for database: grakn
+    Given session opens transaction of type: write
+    Then graql undefine; throws exception
+      """
+      undefine person plays employment:employee;
+      """
+    Then the integrity is validated
+
+
   ###################
   # ATTRIBUTE TYPES #
   ###################
@@ -1317,7 +1339,7 @@ Feature: Graql Undefine Query
     Then answer size is: 0
 
 
-  Scenario: undefining an attribute ownership throws on commit if any instance of the owner has that attribute
+  Scenario: removing an attribute ownership throws an error if it is owned by existing instances
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1330,15 +1352,14 @@ Feature: Graql Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Then graql undefine
+    Then graql undefine; throws exception
       """
       undefine person owns name;
       """
-    Then transaction commits; throws exception
     Then the integrity is validated
 
 
-  Scenario: undefining a key ownership throws an error if there are existing instances of the owner
+  Scenario: undefining a key ownership throws an error if it is owned by existing instances
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -948,7 +948,7 @@ Feature: Graql Undefine Query
   Scenario: undefining a regex on an attribute type removes the regex constraints on the attribute
     When graql undefine
       """
-      undefine email regex ".+@\w+\..+";
+      undefine email regex;
       """
     Then transaction commits
     Then the integrity is validated
@@ -969,24 +969,12 @@ Feature: Graql Undefine Query
     Then answer size is: 1
 
 
-  Scenario: undefining the wrong regex from an attribute type does nothing
-    When graql undefine
+  Scenario: regex pattern should not be specified during an undefine; if it is, then an error is thrown
+    Then graql undefine; throws exception
       """
       undefine email regex ".+@\w.com";
       """
-    Then transaction commits
     Then the integrity is validated
-    When session opens transaction of type: read
-    When get answers of graql query
-      """
-      match $x regex ".+@\w+\..+";
-      """
-    When concept identifiers are
-      |     | check | value |
-      | EMA | label | email |
-    Then uniquely identify answer concepts
-      | x   |
-      | EMA |
 
 
   Scenario: removing playable roles from a super attribute type also removes them from its subtypes

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -1437,11 +1437,14 @@ Feature: Graql Undefine Query
       """
     Given transaction commits
     Given the integrity is validated
-    When session opens transaction of type: write
+    Given connection close all sessions
+    Given connection open data session for database: grakn
+    Given session opens transaction of type: write
     Given graql insert
       """
       insert $x isa person, has email "samuel@grakn.ai";
       """
+    Given transaction commits
     Given the integrity is validated
     Given get answers of graql query
       """
@@ -1455,6 +1458,9 @@ Feature: Graql Undefine Query
     Given uniquely identify answer concepts
       | n   |
       | SAM |
+    Given connection close all sessions
+    Given connection open schema session for database: grakn
+    Given session opens transaction of type: write
     When graql undefine
       """
       undefine rule samuel-email-rule;

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -707,7 +707,6 @@ Feature: Graql Undefine Query
     Then answer size is: 0
 
 
-  # TODO: should this not throw (on undefine)? Currently it doesn't throw on undefine OR commit
   Scenario: removing a role throws an error if it is played by existing roleplayers in relations
     Given graql define
       """

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+#noinspection CucumberUndefinedStep
 Feature: Graql Undefine Query
 
   Background: Open connection and create a simple extensible schema

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Attribute Attachment Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -16,6 +16,7 @@
 #
 
 # TODO: re-enable all steps in file when 3-hop transitivity is resolvable
+#noinspection CucumberUndefinedStep
 Feature: Concept Inequality Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Negation Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Recursion Resolution
 
   In some cases, the inferences made by a rule are used to trigger further inferences by the same rule.

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Relation Inference Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Resolution Test Framework
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/roleplayer-attachment.feature
+++ b/graql/reasoner/roleplayer-attachment.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Roleplayer Attachment Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Rule Interaction Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Schema Query Resolution (Variable Types)
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/type-generation.feature
+++ b/graql/reasoner/type-generation.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Type Generation Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Type Hierarchy Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+#noinspection CucumberUndefinedStep
 Feature: Value Predicate Resolution
 
   Background: Set up databases for resolution testing

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -16,6 +16,7 @@
 #
 
 # TODO: re-enable all steps in file when Grakn is faster
+#noinspection CucumberUndefinedStep
 Feature: Variable Role Resolution
 
   Background: Set up databases for resolution testing


### PR DESCRIPTION
## What is the goal of this PR?

To update our test specification with new Graql and Concept behaviours recently introduced in 2.0

## What are the changes implemented in this PR?

- New scenario: Entity types can only commit keys if every instance owns a distinct key
- New scenario: Relation types must have at least one role in order to commit, unless they are abstract
- New scenario: a cyclic type hierarchy is not allowed
- New scenario: when inserting an attribute, the type and value can be specified in two individual statements
- New scenario: defining a rule is idempotent
- Fixed scenarios that do `undefine person owns email @key` incorrectly (should not use "@key")
- Suppress IntelliJ warnings about undefined steps - they are not supposed to be defined!
