### PR TITLE
Reduce the number of databases in the test case

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -37,12 +37,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection has databases:
       | alice   |
       | bob     |
@@ -50,12 +45,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
 
   Scenario: create many databases in parallel
     When  connection create databases in parallel:
@@ -65,12 +55,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection has databases:
       | alice   |
       | bob     |
@@ -78,12 +63,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
 
   Scenario: delete one database
       # This step should be rewritten once we can create keypsaces without opening sessions
@@ -104,12 +84,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     When  connection delete databases:
       | alice   |
       | bob     |
@@ -117,12 +92,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection does not have databases:
       | alice   |
       | bob     |
@@ -130,12 +100,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection does not have any database
 
   Scenario: delete many databases in parallel
@@ -147,12 +112,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     When  connection delete databases in parallel:
       | alice   |
       | bob     |
@@ -160,12 +120,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection does not have databases:
       | alice   |
       | bob     |
@@ -173,12 +128,7 @@ Feature: Connection Database
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then  connection does not have any database
 
 

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -105,12 +105,7 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     When connection open sessions for databases:
       | alice   |
       | bob     |
@@ -118,12 +113,7 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then sessions are null: false
     Then sessions are open: true
     Then sessions have databases:
@@ -133,12 +123,7 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
 
   Scenario: for many databases, open many sessions in parallel
     When connection create databases:
@@ -148,12 +133,7 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     When connection open sessions in parallel for databases:
       | alice   |
       | bob     |
@@ -161,12 +141,7 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+
     Then sessions in parallel are null: false
     Then sessions in parallel are open: true
     Then sessions in parallel have databases:
@@ -176,9 +151,4 @@ Feature: Connection Session
       | dylan   |
       | eve     |
       | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
+


### PR DESCRIPTION
## What is the goal of this PR?

Due to the recent split of schema db and data db in Grakn 2.0 (https://github.com/graknlabs/grakn-2.0/pull/136), the memory usage is doubled and caused CI to run out of memory. Therefore, we have reduced the number of databases from 12 to 6.