### PR TITLE
Remove server cleanup steps

### DIFF
--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -20,7 +20,6 @@ Feature: Concept Attribute
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -20,7 +20,6 @@ Feature: Concept Entity
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -20,7 +20,6 @@ Feature: Concept Relation
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -20,7 +20,6 @@ Feature: Concept Attribute Type
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -20,7 +20,6 @@ Feature: Concept Entity Type
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -20,7 +20,6 @@ Feature: Concept Relation Type and Role Type
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/concept/type/thingtype.feature
+++ b/concept/type/thingtype.feature
@@ -20,7 +20,6 @@ Feature: Concept Thing Type
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -20,7 +20,6 @@ Feature: Connection Database
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
 
   Scenario: create one database

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -20,7 +20,6 @@ Feature: Connection Session
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
 
   Scenario: for one database, open one session

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -20,7 +20,6 @@ Feature: Connection Transaction
 
   Background:
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
 
   Scenario: one database, one session, one transaction to read

--- a/graql/explanation/language.feature
+++ b/graql/explanation/language.feature
@@ -20,7 +20,6 @@ Feature: Graql Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | test_explanation |
     Given transaction is initialised

--- a/graql/explanation/reasoner.feature
+++ b/graql/explanation/reasoner.feature
@@ -22,7 +22,6 @@ Feature: Graql Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | test_explanation |
     Given transaction is initialised

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -20,7 +20,6 @@ Feature: Graql Define Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -20,7 +20,6 @@ Feature: Graql Delete Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -20,7 +20,6 @@ Feature: Graql Get Clause
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -20,7 +20,6 @@ Feature: Graql Insert Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -20,7 +20,6 @@ Feature: Graql Match Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -19,7 +19,6 @@ Feature: Graql Rule Validation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | test_rule_validation |
     Given transaction is initialised

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -20,7 +20,6 @@ Feature: Graql Undefine Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
     Given connection create database: grakn
     Given connection open schema session for database: grakn

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -28,7 +28,6 @@ Feature: Attribute Attachment Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -21,7 +21,6 @@ Feature: Attribute Attachment Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -22,7 +22,6 @@ Feature: Concept Inequality Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -21,7 +21,6 @@ Feature: Negation Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -24,7 +24,6 @@ Feature: Recursion Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -21,7 +21,6 @@ Feature: Relation Inference Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -21,7 +21,6 @@ Feature: Resolution Test Framework
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -21,7 +21,6 @@ Feature: Rule Interaction Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -21,7 +21,6 @@ Feature: Schema Query Resolution (Variable Types)
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -21,7 +21,6 @@ Feature: Type Hierarchy Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -21,7 +21,6 @@ Feature: Value Predicate Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -22,7 +22,6 @@ Feature: Variable Role Resolution
   Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all databases
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |


### PR DESCRIPTION
## What is the goal of this PR?

Currently before each scenario, we explicitly include steps to delete databases. This means the last test might not clean up the resources, which makes reasoning about resources harder.

Instead, we move to the strategy of letting host of BDD tests clean up all resources after each run of scenario. This way, the resources will always be released at the end of each test run. The BDD tests can also focus on the actual behaviour testing, without the need of including clean up steps.

## What are the changes implemented in this PR?

- Remove server cleanup steps that delete all databases.
