### PR TITLE
Make concept map validation steps more concise

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -23,13 +23,11 @@ Feature: Connection Database
     Given connection does not have any database
 
   Scenario: create one database
-    When  connection create database:
-      | alice |
-    Then  connection has database:
-      | alice |
+    When connection create database: alice
+    Then connection has database: alice
 
   Scenario: create many databases
-    When  connection create databases:
+    When connection create databases:
       | alice   |
       | bob     |
       | charlie |
@@ -66,13 +64,10 @@ Feature: Connection Database
 
   Scenario: delete one database
       # This step should be rewritten once we can create keypsaces without opening sessions
-    Given connection create database:
-      | alice |
-    When  connection delete database:
-      | alice |
-    Then  connection does not have database:
-      | alice |
-    Then  connection does not have any database
+    Given connection create database: alice
+    When connection delete database: alice
+    Then connection does not have database: alice
+    Then connection does not have any database
 
   Scenario: connection can delete many databases
       # This step should be rewritten once we can create keypsaces without opening sessions
@@ -100,7 +95,7 @@ Feature: Connection Database
       | eve     |
       | frank   |
 
-    Then  connection does not have any database
+    Then connection does not have any database
 
   Scenario: delete many databases in parallel
       # This step should be rewritten once we can create keypsaces without opening sessions
@@ -120,7 +115,7 @@ Feature: Connection Database
       | eve     |
       | frank   |
 
-    Then  connection does not have databases:
+    Then connection does not have databases:
       | alice   |
       | bob     |
       | charlie |
@@ -128,38 +123,29 @@ Feature: Connection Database
       | eve     |
       | frank   |
 
-    Then  connection does not have any database
+    Then connection does not have any database
 
 
   Scenario: delete a database causes open sessions to fail
-    When connection create database:
-      | grakn |
-    When connection open session for database:
-      | grakn |
-    When  connection delete database:
-      | grakn |
-    Then  connection does not have database:
-      | grakn |
-    Then for each session, open transaction of type; throws exception
-      | write |
+    When connection create database: grakn
+    When connection open session for database: grakn
+    When connection delete database: grakn
+    Then connection does not have database: grakn
+    Then session, open transaction of type; throws exception: write
 
   @ignore-grakn-core
   Scenario: delete a database causes open transactions to fail
-    When connection create database:
-      | grakn |
-    When connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | write |
-    When connection delete database:
-      | grakn |
-    Then connection does not have database:
-      | grakn |
+    When connection create database: grakn
+    When connection opens session for database: grakn
+    When session opens transaction of type: write
+    When connection delete database: grakn
+    Then connection does not have database: grakn
     Then for each transaction, define query; throws exception containing "transaction has been closed"
       """
       define person sub entity;
       """
 
   Scenario: delete a nonexistent database throws an error
-    When connection delete database; throws exception
-      | grakn |
+    When connection delete database; throws exception: grakn
+
+    #TODO: CONTINUE REMOVING SINGLETONS

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -23,18 +23,14 @@ Feature: Connection Session
     Given connection does not have any database
 
   Scenario: for one database, open one session
-    When connection create database:
-      | grakn |
-    When connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    When connection open session for database: grakn
     Then session is null: false
     Then session is open: true
-    Then session has database:
-      | grakn |
+    Then session has database: grakn
 
   Scenario: for one database, open many sessions
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     When connection open sessions for databases:
       | grakn |
       | grakn |
@@ -65,8 +61,7 @@ Feature: Connection Session
       | grakn |
 
   Scenario: for one database, open many sessions in parallel
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     When connection open sessions in parallel for databases:
       | grakn |
       | grakn |
@@ -151,3 +146,24 @@ Feature: Connection Session
       | eve     |
       | frank   |
 
+  Scenario: write schema in a data session throws
+    When connection create database: grakn
+    Given connection open data session for database: grakn
+    When session opens transaction of type: write
+    Then graql define; throws exception containing "session type does not allow"
+      """
+      define person sub entity;
+      """
+
+  Scenario: write data in a schema session throws
+    When connection create database: grakn
+    Given connection open schema session for database: grakn
+    When session opens transaction of type: write
+    Then graql define
+      """
+      define person sub entity;
+      """
+    Then graql put; throws exception containing "session type does not allow"
+      """
+      put $x isa person;
+      """

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -163,7 +163,7 @@ Feature: Connection Session
       """
       define person sub entity;
       """
-    Then graql put; throws exception containing "session type does not allow"
+    Then graql insert; throws exception containing "session type does not allow"
       """
       put $x isa person;
       """

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -165,5 +165,5 @@ Feature: Connection Session
       """
     Then graql insert; throws exception containing "session type does not allow"
       """
-      put $x isa person;
+      insert $x isa person;
       """

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -580,7 +580,8 @@ Feature: Connection Transaction
     When connection create database: grakn
     Given connection open schema session for database: grakn
     When session opens transaction of type: read
-    Then graql define; throws exception containing "is read only"
+    Then graql define
       """
       define person sub entity;
       """
+    Then transaction commit; throws exception containing "write transactions can be committed"

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -617,11 +617,10 @@ Feature: Connection Transaction
 #  Scenario: one database, many sessions in parallel, many transactions in parallel to write
 
 
-  @ignore-grakn-2.0
   Scenario: write in a read transaction throws
     When connection create database:
       | grakn |
-    Given connection open session for database:
+    Given connection open schema session for database:
       | grakn |
     When for each session, open transaction of type:
       | read |

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -23,56 +23,39 @@ Feature: Connection Transaction
     Given connection does not have any database
 
   Scenario: one database, one session, one transaction to read
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | read |
-    Then for each session, transaction is null: false
-    Then for each session, transaction is open: true
-    Then for each session, transaction has type:
-      | read |
+    When connection create database: grakn
+    Given connection open session for database: grakn
+    When session opens transaction of type: read
+    Then session transaction is null: false
+    Then session transaction is open: true
+    Then session transaction has type: read
 
   Scenario: one database, one session, one transaction to write
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | write |
-    Then for each session, transaction is null: false
-    Then for each session, transaction is open: true
-    Then for each session, transaction has type:
-      | write |
+    When connection create database: grakn
+    Given connection open session for database: grakn
+    When session opens transaction of type: write
+    Then session transaction is null: false
+    Then session transaction is open: true
+    Then session transaction has type: write
 
   Scenario: one database, one session, one committed write transaction is closed
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | write |
-    Then for each session, transaction commits
-    Then for each session, transaction commits; throws exception
+    When connection create database: grakn
+    Given connection open session for database: grakn
+    When session opens transaction of type: write
+    Then session transaction commits
+    Then session transaction commits; throws exception
 
   Scenario: one database, one session, re-committing transaction throws
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | write |
+    When connection create database: grakn
+    Given connection open session for database: grakn
+    When for each session, open transaction of type: write
     Then for each session, transaction commits
     Then for each session, transaction commits; throws exception
 
   Scenario: one database, one session, transaction close is idempotent
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | write |
+    When connection create database: grakn
+    Given connection open session for database: grakn
+    When for each session, open transaction of type: write
     Then for each session, transaction closes
     Then for each session, transaction is open: false
     Then for each session, transaction closes
@@ -80,10 +63,8 @@ Feature: Connection Transaction
 
   @ignore-grakn-core
   Scenario: one database, one session, many transactions to read
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions of type:
       | read |
       | read |
@@ -115,10 +96,8 @@ Feature: Connection Transaction
 
   @ignore-grakn-core
   Scenario: one database, one session, many transactions to write
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions of type:
       | write |
       | write |
@@ -150,10 +129,8 @@ Feature: Connection Transaction
 
   @ignore-grakn-core
   Scenario: one database, one session, many transactions to read and write
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions of type:
       | read  |
       | write |
@@ -184,10 +161,8 @@ Feature: Connection Transaction
       | write |
 
   Scenario: one database, one session, many transactions in parallel to read
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions in parallel of type:
       | read |
       | read |
@@ -218,10 +193,8 @@ Feature: Connection Transaction
       | read |
 
   Scenario: one database, one session, many transactions in parallel to write
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions in parallel of type:
       | write |
       | write |
@@ -252,10 +225,8 @@ Feature: Connection Transaction
       | write |
 
   Scenario: one database, one session, many transactions in parallel to read and write
-    When connection create database:
-      | grakn |
-    Given connection open session for database:
-      | grakn |
+    When connection create database: grakn
+    Given connection open session for database: grakn
     When for each session, open transactions in parallel of type:
       | read  |
       | write |
@@ -286,8 +257,7 @@ Feature: Connection Transaction
       | write |
 
   Scenario: one database, many sessions, one transaction to read
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -301,16 +271,13 @@ Feature: Connection Transaction
       | grakn |
       | grakn |
       | grakn |
-    When for each session, open transaction of type:
-      | read |
+    When for each session, open transaction of type: read
     Then for each session, transaction is null: false
     Then for each session, transaction is open: true
-    Then for each session, transaction has type:
-      | read |
+    Then for each session, transaction has type: read
 
   Scenario: one database, many sessions, one transaction to write
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -324,17 +291,14 @@ Feature: Connection Transaction
       | grakn |
       | grakn |
       | grakn |
-    When for each session, open transaction of type:
-      | write |
+    When for each session, open transaction of type: write
     Then for each session, transaction is null: false
     Then for each session, transaction is open: true
-    Then for each session, transaction has type:
-      | write |
+    Then for each session, transaction has type: write
 
   @ignore-grakn-core
   Scenario: one database, many sessions, many transactions to read
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -379,8 +343,7 @@ Feature: Connection Transaction
 
   @ignore-grakn-core
   Scenario: one database, many sessions, many transactions to write
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -425,8 +388,7 @@ Feature: Connection Transaction
 
   @ignore-grakn-core
   Scenario: one database, many sessions, many transactions to read and write
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -470,8 +432,7 @@ Feature: Connection Transaction
       | write |
 
   Scenario: one database, many sessions, many transactions in parallel to read
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -515,8 +476,7 @@ Feature: Connection Transaction
       | read |
 
   Scenario: one database, many sessions, many transactions in parallel to write
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -560,8 +520,7 @@ Feature: Connection Transaction
       | write |
 
   Scenario: one database, many sessions, many transactions in parallel to read and write
-    When connection create database:
-      | grakn |
+    When connection create database: grakn
     Given connection open sessions for database:
       | grakn |
       | grakn |
@@ -618,14 +577,10 @@ Feature: Connection Transaction
 
 
   Scenario: write in a read transaction throws
-    When connection create database:
-      | grakn |
-    Given connection open schema session for database:
-      | grakn |
-    When for each session, open transaction of type:
-      | read |
-    Then for each transaction, define query; throws exception containing "is read only"
+    When connection create database: grakn
+    Given connection open schema session for database: grakn
+    When session opens transaction of type: read
+    Then graql define; throws exception containing "is read only"
       """
       define person sub entity;
       """
-

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -584,4 +584,4 @@ Feature: Connection Transaction
       """
       define person sub entity;
       """
-    Then transaction commit; throws exception containing "write transactions can be committed"
+    Then transaction commits; throws exception containing "write transactions can be committed"

--- a/graql/explanation/language.feature
+++ b/graql/explanation/language.feature
@@ -50,13 +50,9 @@ Feature: Graql Reasoning Explanation
       match $p isa person;
       """
 
-    Then concept identifiers are
-      |    | check | value      |
-      | AL | key   | name:Alice |
-
     Then uniquely identify answer concepts
-      | p  |
-      | AL |
+      | p              |
+      | key:name:Alice |
 
     Then answers contain explanation tree
       |   | children | vars | identifiers | explanation | pattern                                    |
@@ -107,8 +103,8 @@ Feature: Graql Reasoning Explanation
       | KCn | value | name:King's Cross |
 
     Then uniquely identify answer concepts
-      | k  | l   | n   |
-      | KC | LDN | KCn |
+      |          k            |       l         |           n             |
+      | key:name:King's Cross | key:name:London | value:name:King's Cross |
 
     Then answers contain explanation tree
       |   | children | vars    | identifiers  | explanation | pattern                                                                                                                                                        |

--- a/graql/explanation/language.feature
+++ b/graql/explanation/language.feature
@@ -162,8 +162,8 @@ Feature: Graql Reasoning Explanation
       | KCn | value | name:King's Cross |
 
     Then uniquely identify answer concepts
-      | k  | l   | u  | n   |
-      | KC | LDN | UK | KCn |
+      | k                     | l               | u           | n                       |
+      | key:name:King's Cross | key:name:London | key:name:UK | value:name:King's Cross |
 
     Then answers contain explanation tree
       |   | children | vars       | identifiers      | explanation | pattern                                                                                                                                                                                                                                       |
@@ -210,8 +210,8 @@ Feature: Graql Reasoning Explanation
       | N   | value | name:another-company |
 
     Then uniquely identify answer concepts
-      | com | n |
-      | ACO | N |
+      | com              | n                          |
+      | key:company-id:1 | value:name:another-company |
 
     Then answers contain explanation tree
       |   | children | vars   | identifiers | explanation | pattern                                                                                                                       |
@@ -258,8 +258,8 @@ Feature: Graql Reasoning Explanation
       | N2  | value | name:another-company |
 
     Then uniquely identify answer concepts
-      | com |
-      | ACO |
+      | com              |
+      | key:company-id:1 |
 
     Then answers contain explanation tree
       |   | children | vars    | identifiers | explanation | pattern                                                                                                                                                            |
@@ -306,8 +306,8 @@ Feature: Graql Reasoning Explanation
       | N2  | value | name:another-company |
 
     Then uniquely identify answer concepts
-      | com |
-      | ACO |
+      | com              |
+      | key:company-id:1 |
 
     Then answers contain explanation tree
       |   | children | vars    | identifiers | explanation | pattern                                                                                                                                                                                                                              |

--- a/graql/explanation/reasoner.feature
+++ b/graql/explanation/reasoner.feature
@@ -63,8 +63,8 @@ Feature: Graql Reasoning Explanation
       | CON | value | name:the-company |
 
     Then uniquely identify answer concepts
-      | co | n   |
-      | CO | CON |
+      | co               | n                      |
+      | key:company-id:0 | value:name:the-company |
 
     Then rules are
       |                  | when                 | then                            |
@@ -126,8 +126,8 @@ Feature: Graql Reasoning Explanation
       | LIA | value | is-liable:true   |
 
     Then uniquely identify answer concepts
-      | co | l   |
-      | CO | LIA |
+      | co               | l                    |
+      | key:company-id:0 | value:is-liable:true |
 
     Then rules are
       |                   | when                                                       | then                             |
@@ -195,9 +195,9 @@ Feature: Graql Reasoning Explanation
       | KCN | value | name:King's Cross |
 
     Then uniquely identify answer concepts
-      | k  | l   | n   |
-      | KC | UK  | KCN |
-      | KC | LDN | KCN |
+      | k                     | l               | n                       |
+      | key:name:King's Cross | key:name:UK     | value:name:King's Cross |
+      | key:name:King's Cross | key:name:London | value:name:King's Cross |
 
     Then rules are
       |                                 | when                                                                                                                 | then                                                         |
@@ -281,8 +281,8 @@ Feature: Graql Reasoning Explanation
       """
 
     Then uniquely identify answer concepts
-      | w   | m   |
-      | ALI | BOB |
+      | w               | m               |
+      | key:person-id:0 | key:person-id:1 |
 
     Then answers contain explanation tree
       |   | children | vars          | identifiers          | explanation          | pattern                                                                                                                                                                                            |
@@ -298,8 +298,8 @@ Feature: Graql Reasoning Explanation
       """
 
     Then uniquely identify answer concepts
-      | w   | m   |
-      | ALI | BOB |
+      | w               | m               |
+      | key:person-id:0 | key:person-id:1 |
 
     Then answers contain explanation tree
       |   | children | vars          | identifiers          | explanation          | pattern                                                                                                                                                                                            |
@@ -361,8 +361,8 @@ Feature: Graql Reasoning Explanation
       | N2  | value | name:another-company |
 
     Then uniquely identify answer concepts
-      | com |
-      | ACO |
+      | com              |
+      | key:company-id:1 |
 
     Then rules are
       |                   | when                                                   | then                                |
@@ -424,8 +424,8 @@ Feature: Graql Reasoning Explanation
       | LIA | value | is-liable:true |
 
     Then uniquely identify answer concepts
-      | com | lia |
-      | ACO | LIA |
+      | com              | lia                  |
+      | key:company-id:1 | value:is-liable:true |
 
     Then rules are
       |                   | when                                                                | then                                |
@@ -487,8 +487,8 @@ Feature: Graql Reasoning Explanation
       | ACO | key   | company-id:1 |
 
     Then uniquely identify answer concepts
-      | com |
-      | ACO |
+      | com              |
+      | key:company-id:1 |
 
     Then rules are
       |                   | when                                                      | then                                |

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -1225,13 +1225,9 @@ Feature: Graql Define Query
       $name type name; $name abstract;
       $location type location-name, sub name;
       """
-    When concept identifiers are
-      |     | check | value         |
-      | NAM | label | name          |
-      | LOC | label | location-name |
     Then uniquely identify answer concepts
-      | name | location |
-      | NAM  | LOC      |
+      | name        | location            |
+      | label:name  | label:location-name |
     Then the integrity is validated
 
 

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -58,12 +58,9 @@ Feature: Graql Define Query
       """
       match $x type dog;
       """
-    When concept identifiers are
-      |     | check | value |
-      | DOG | label | dog   |
     Then uniquely identify answer concepts
-      | x   |
-      | DOG |
+      | x         |
+      | label:dog |
 
 
   Scenario: a new entity type can be defined as a subtype, creating a new child of its parent type
@@ -78,14 +75,10 @@ Feature: Graql Define Query
       """
       match $x sub person;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHD | label | child  |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHD |
+      | x            |
+      | label:person |
+      | label:child  |
 
 
   Scenario: when defining that a type owns a non-existent thing, an error is thrown
@@ -148,14 +141,10 @@ Feature: Graql Define Query
       """
       match $x plays employment:employee;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHD | label | child  |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHD |
+      | x            |
+      | label:person |
+      | label:child  |
 
 
   Scenario: a newly defined entity subtype inherits playable roles from all of its supertypes
@@ -173,18 +162,12 @@ Feature: Graql Define Query
       """
       match $x plays employment:employee;
       """
-    When concept identifiers are
-      |     | check | value    |
-      | PER | label | person   |
-      | ATH | label | athlete  |
-      | RUN | label | runner   |
-      | SPR | label | sprinter |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | ATH |
-      | RUN |
-      | SPR |
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
 
 
   Scenario: a newly defined entity subtype inherits attribute ownerships from its parent type
@@ -199,14 +182,10 @@ Feature: Graql Define Query
       """
       match $x owns name;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHD | label | child  |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHD |
+      | x            |
+      | label:person |
+      | label:child  |
 
 
   Scenario: a newly defined entity subtype inherits attribute ownerships from all of its supertypes
@@ -224,18 +203,12 @@ Feature: Graql Define Query
       """
       match $x owns name;
       """
-    When concept identifiers are
-      |     | check | value    |
-      | PER | label | person   |
-      | ATH | label | athlete  |
-      | RUN | label | runner   |
-      | SPR | label | sprinter |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | ATH |
-      | RUN |
-      | SPR |
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
 
 
   Scenario: a newly defined entity subtype inherits keys from its parent type
@@ -250,14 +223,10 @@ Feature: Graql Define Query
       """
       match $x owns email @key;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHD | label | child  |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHD |
+      | x            |
+      | label:person |
+      | label:child  |
 
 
   Scenario: a newly defined entity subtype inherits keys from all of its supertypes
@@ -275,18 +244,12 @@ Feature: Graql Define Query
       """
       match $x owns email @key;
       """
-    When concept identifiers are
-      |     | check | value    |
-      | PER | label | person   |
-      | ATH | label | athlete  |
-      | RUN | label | runner   |
-      | SPR | label | sprinter |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | ATH |
-      | RUN |
-      | SPR |
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
 
 
   Scenario: defining a playable role is idempotent
@@ -304,12 +267,9 @@ Feature: Graql Define Query
       """
       match $x plays home-ownership:home;
       """
-    When concept identifiers are
-      |     | check | value |
-      | HOU | label | house |
     Then uniquely identify answer concepts
-      | x   |
-      | HOU |
+      | x           |
+      | label:house |
 
 
   Scenario: defining an attribute ownership is idempotent
@@ -326,12 +286,9 @@ Feature: Graql Define Query
       """
       match $x owns price;
       """
-    When concept identifiers are
-      |     | check | value |
-      | HOU | label | house |
     Then uniquely identify answer concepts
-      | x   |
-      | HOU |
+      | x           |
+      | label:house |
 
 
   Scenario: defining a key ownership is idempotent
@@ -348,12 +305,9 @@ Feature: Graql Define Query
       """
       match $x owns address @key;
       """
-    When concept identifiers are
-      |     | check | value |
-      | HOU | label | house |
     Then uniquely identify answer concepts
-      | x   |
-      | HOU |
+      | x           |
+      | label:house |
 
 
   Scenario: defining a type without a 'sub' clause throws
@@ -433,12 +387,9 @@ Feature: Graql Define Query
       """
       match $x type pet-ownership;
       """
-    When concept identifiers are
-      |     | check | value         |
-      | POW | label | pet-ownership |
     Then uniquely identify answer concepts
-      | x   |
-      | POW |
+      | x                   |
+      | label:pet-ownership |
 
 
   Scenario: a new relation type can be defined as a subtype, creating a new child of its parent type
@@ -453,14 +404,10 @@ Feature: Graql Define Query
       """
       match $x sub employment;
       """
-    When concept identifiers are
-      |     | check | value          |
-      | EMP | label | employment     |
-      | FUN | label | fun-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | FUN |
+      | x                    |
+      | label:employment     |
+      | label:fun_employment |
 
 
   Scenario: defining a relation type throws on commit if it has no roleplayers and is not abstract
@@ -484,14 +431,10 @@ Feature: Graql Define Query
       """
       match $x relates employee;
       """
-    When concept identifiers are
-      |     | check | value                |
-      | EMP | label | employment           |
-      | PTT | label | part-time-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | PTT |
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
 
 
   Scenario: a newly defined relation subtype inherits roles from all of its supertypes
@@ -513,24 +456,18 @@ Feature: Graql Define Query
         $x relates parent;
         $x relates child;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | PAR | label | parenthood |
     Then uniquely identify answer concepts
-      | x   |
-      | PAR |
+      | x                 |
+      | label:parenthood |
     When get answers of graql query
       """
       match
         $x relates father;
         $x relates son;
       """
-    When concept identifiers are
-      |     | check | value          |
-      | FSH | label | father-sonhood |
     Then uniquely identify answer concepts
-      | x   |
-      | FSH |
+      | x                    |
+      | label:father-sonhood |
 
 
   Scenario: when a relation type's role is overridden, it creates a sub-role of the parent role type
@@ -548,18 +485,12 @@ Feature: Graql Define Query
       match
       $x sub parenthood:parent; $y sub parenthood:child; get $x, $y;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PAR | label | parent |
-      | FAT | label | father |
-      | CHI | label | child  |
-      | SON | label | son    |
     Then uniquely identify answer concepts
-      | x   | y   |
-      | PAR | CHI |
-      | FAT | CHI |
-      | PAR | SON |
-      | FAT | SON |
+      | x            | y           |
+      | label:parent | label:child |
+      | label:father | label:child |
+      | label:parent | label:son   |
+      | label:father | label:son   |
 
 
   Scenario: an overridden role is no longer associated with the relation type that overrides it
@@ -574,12 +505,9 @@ Feature: Graql Define Query
       """
       match $x relates employee;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x                |
+      | label:employment |
 
 
   Scenario: when overriding a role that doesn't exist on the parent relation, an error is thrown
@@ -603,14 +531,10 @@ Feature: Graql Define Query
       """
       match $x plays income:source;
       """
-    When concept identifiers are
-      |     | check | value               |
-      | EMP | label | employment          |
-      | CEM | label | contract-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | CEM |
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
 
 
   Scenario: a newly defined relation subtype inherits playable roles from all of its supertypes
@@ -628,18 +552,12 @@ Feature: Graql Define Query
       """
       match $x plays income:source;
       """
-    When concept identifiers are
-      |     | check | value                       |
-      | EMP | label | employment                  |
-      | TRN | label | transport-employment        |
-      | AVI | label | aviation-employment         |
-      | FAA | label | flight-attendant-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | TRN |
-      | AVI |
-      | FAA |
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
 
 
   Scenario: a newly defined relation subtype inherits attribute ownerships from its parent type
@@ -654,14 +572,10 @@ Feature: Graql Define Query
       """
       match $x owns start-date;
       """
-    When concept identifiers are
-      |     | check | value               |
-      | EMP | label | employment          |
-      | CEM | label | contract-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | CEM |
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
 
 
   Scenario: a newly defined relation subtype inherits attribute ownerships from all of its supertypes
@@ -679,18 +593,12 @@ Feature: Graql Define Query
       """
       match $x owns start-date;
       """
-    When concept identifiers are
-      |     | check | value                       |
-      | EMP | label | employment                  |
-      | TRN | label | transport-employment        |
-      | AVI | label | aviation-employment         |
-      | FAA | label | flight-attendant-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | TRN |
-      | AVI |
-      | FAA |
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
 
 
   Scenario: a newly defined relation subtype inherits keys from its parent type
@@ -705,14 +613,10 @@ Feature: Graql Define Query
       """
       match $x owns employment-reference-code @key;
       """
-    When concept identifiers are
-      |     | check | value               |
-      | EMP | label | employment          |
-      | CEM | label | contract-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | CEM |
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
 
 
   Scenario: a newly defined relation subtype inherits keys from all of its supertypes
@@ -730,18 +634,12 @@ Feature: Graql Define Query
       """
       match $x owns employment-reference-code @key;
       """
-    When concept identifiers are
-      |     | check | value                       |
-      | EMP | label | employment                  |
-      | TRN | label | transport-employment        |
-      | AVI | label | aviation-employment         |
-      | FAA | label | flight-attendant-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | TRN |
-      | AVI |
-      | FAA |
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
 
 
   Scenario: a relation type can be defined with no roleplayers when it is marked as abstract
@@ -756,12 +654,9 @@ Feature: Graql Define Query
       """
       match $x type connection;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | CON | label | connection |
     Then uniquely identify answer concepts
-      | x   |
-      | CON |
+      | x                |
+      | label:connection |
 
 
   Scenario: when defining a relation type, duplicate 'relates' are idempotent
@@ -778,12 +673,9 @@ Feature: Graql Define Query
       """
       match $x relates parent; $x relates child;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | PAR | label | parenthood |
     Then uniquely identify answer concepts
-      | x   |
-      | PAR |
+      | x                |
+      | label:parenthood |
 
 
   Scenario: unrelated relations are allowed to have roles with the same name
@@ -800,14 +692,10 @@ Feature: Graql Define Query
       """
       match $x relates owner;
       """
-    When concept identifiers are
-      |     | check | value     |
-      | OWN | label | ownership |
-      | LOA | label | loan      |
     Then uniquely identify answer concepts
-      | x   |
-      | OWN |
-      | LOA |
+      | x               |
+      | label:ownership |
+      | label:loan      |
 
 
   ###################
@@ -869,14 +757,10 @@ Feature: Graql Define Query
       """
       match $x sub code;
       """
-    When concept identifiers are
-      |     | check | value     |
-      | COD | label | code      |
-      | DOC | label | door-code |
     Then uniquely identify answer concepts
-      | x   |
-      | COD |
-      | DOC |
+      | x               |
+      | label:code      |
+      | label:door-code |
 
 
   Scenario: a newly defined attribute subtype inherits the value type of its parent
@@ -893,12 +777,9 @@ Feature: Graql Define Query
       """
       match $x type door-code, value string;
       """
-    When concept identifiers are
-      |     | check | value     |
-      | DOC | label | door-code |
     Then uniquely identify answer concepts
-      | x   |
-      | DOC |
+      | x               |
+      | label:door-code |
 
 
   Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
@@ -921,12 +802,9 @@ Feature: Graql Define Query
       """
       match $x regex "^(yes|no|maybe)$";
       """
-    When concept identifiers are
-      |     | check | value    |
-      | RES | label | response |
     Then uniquely identify answer concepts
-      | x   |
-      | RES |
+      | x              |
+      | label:resource |
 
 
   Scenario: a regex constraint cannot be defined on an attribute type whose value type is anything other than 'string'
@@ -953,14 +831,10 @@ Feature: Graql Define Query
       """
       match $x plays car-sales-listing:available-colour;
       """
-    When concept identifiers are
-      |     | check | value            |
-      | COL | label | colour           |
-      | GRC | label | grayscale-colour |
     Then uniquely identify answer concepts
-      | x   |
-      | COL |
-      | GRC |
+      | x                      |
+      | label:colour           |
+      | label:grayscale-colour |
 
 
   Scenario: a newly defined attribute subtype inherits playable roles from all of its supertypes
@@ -981,18 +855,12 @@ Feature: Graql Define Query
       """
       match $x plays phone-contact:number;
       """
-    When concept identifiers are
-      |     | check | value                      |
-      | PHN | label | phone-number               |
-      | UKP | label | uk-phone-number            |
-      | UKL | label | uk-landline-number         |
-      | UPM | label | uk-premium-landline-number |
     Then uniquely identify answer concepts
-      | x   |
-      | PHN |
-      | UKP |
-      | UKL |
-      | UPM |
+      | x                                |
+      | label:phone-number               |
+      | label:uk-phone-number            |
+      | label:uk-landline-number         |
+      | label:uk-premium-landline-number |
 
 
   Scenario: a newly defined attribute subtype inherits attribute ownerships from its parent type
@@ -1010,14 +878,10 @@ Feature: Graql Define Query
       """
       match $x owns brightness;
       """
-    When concept identifiers are
-      |     | check | value            |
-      | COL | label | colour           |
-      | GRC | label | grayscale-colour |
     Then uniquely identify answer concepts
-      | x   |
-      | COL |
-      | GRC |
+      | x                      |
+      | label:colour           |
+      | label:grayscale-colour |
 
 
   Scenario: a newly defined attribute subtype inherits attribute ownerships from all of its supertypes
@@ -1037,18 +901,12 @@ Feature: Graql Define Query
       """
       match $x owns country-calling-code;
       """
-    When concept identifiers are
-      |     | check | value                      |
-      | PHN | label | phone-number               |
-      | UKP | label | uk-phone-number            |
-      | UKL | label | uk-landline-number         |
-      | UPM | label | uk-premium-landline-number |
     Then uniquely identify answer concepts
-      | x   |
-      | PHN |
-      | UKP |
-      | UKL |
-      | UPM |
+      | x                                |
+      | label:phone-number               |
+      | label:uk-phone-number            |
+      | label:uk-landline-number         |
+      | label:uk-premium-landline-number |
 
 
   Scenario: a newly defined attribute subtype inherits keys from its parent type
@@ -1066,14 +924,10 @@ Feature: Graql Define Query
       """
       match $x owns hex-value @key;
       """
-    When concept identifiers are
-      |     | check | value            |
-      | COL | label | colour           |
-      | GRC | label | grayscale-colour |
     Then uniquely identify answer concepts
-      | x   |
-      | COL |
-      | GRC |
+      | x                      |
+      | label:colour           |
+      | label:grayscale-colour |
 
 
   Scenario: a newly defined attribute subtype inherits keys from all of its supertypes
@@ -1093,18 +947,12 @@ Feature: Graql Define Query
       """
       match $x owns hex-value @key;
       """
-    When concept identifiers are
-      |     | check | value                |
-      | COL | label | colour               |
-      | DRK | label | dark-colour          |
-      | DKR | label | dark-red-colour      |
-      | VDR | label | very-dark-red-colour |
     Then uniquely identify answer concepts
-      | x   |
-      | COL |
-      | DRK |
-      | DKR |
-      | VDR |
+      | x                          |
+      | label:colour               |
+      | label:dark-colour          |
+      | label:dark-red-colour      |
+      | label:very-dark-red-colour |
 
 
   Scenario Outline: a type can own a '<value_type>' attribute type
@@ -1121,12 +969,9 @@ Feature: Graql Define Query
       """
       match $x owns <label>;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
   Examples:
     | value_type | label             |
@@ -1164,12 +1009,9 @@ Feature: Graql Define Query
       """
       match $x type animal; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | ANI | label | animal |
     Then uniquely identify answer concepts
-      | x   |
-      | ANI |
+      | x            |
+      | label:animal |
 
 
   Scenario: a concrete entity type can be defined as a subtype of an abstract entity type
@@ -1186,14 +1028,10 @@ Feature: Graql Define Query
       """
       match $x sub animal;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | ANI | label | animal |
-      | HOR | label | horse  |
     Then uniquely identify answer concepts
-      | x   |
-      | ANI |
-      | HOR |
+      | x            |
+      | label:animal |
+      | label:horse  |
 
 
   Scenario: an abstract entity type can be defined as a subtype of another abstract entity type
@@ -1210,14 +1048,10 @@ Feature: Graql Define Query
       """
       match $x sub animal; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | ANI | label | animal |
-      | FSH | label | fish   |
     Then uniquely identify answer concepts
-      | x   |
-      | ANI |
-      | FSH |
+      | x            |
+      | label:animal |
+      | label:fish   |
 
 
   Scenario: an abstract entity type can be defined as a subtype of a concrete entity type
@@ -1234,12 +1068,9 @@ Feature: Graql Define Query
       """
       match $x sub exception, abstract;
       """
-    When concept identifiers are
-      |     | check | value           |
-      | GRA | label | grakn-exception |
     Then uniquely identify answer concepts
-      | x   |
-      | GRA |
+      | x                     |
+      | label:grakn-exception |
 
 
   Scenario: an abstract relation type can be defined
@@ -1254,12 +1085,9 @@ Feature: Graql Define Query
       """
       match $x type membership; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | MEM | label | membership |
     Then uniquely identify answer concepts
-      | x   |
-      | MEM |
+      | x                |
+      | label:membership |
 
 
   Scenario: a concrete relation type can be defined as a subtype of an abstract relation type
@@ -1276,14 +1104,10 @@ Feature: Graql Define Query
       """
       match $x sub membership;
       """
-    When concept identifiers are
-      |     | check | value          |
-      | MEM | label | membership     |
-      | GYM | label | gym-membership |
     Then uniquely identify answer concepts
-      | x   |
-      | MEM |
-      | GYM |
+      | x                    |
+      | label:membership     |
+      | label:gym-membership |
 
 
   Scenario: an abstract relation type can be defined as a subtype of another abstract relation type
@@ -1300,14 +1124,10 @@ Feature: Graql Define Query
       """
       match $x sub requirement; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value            |
-      | REQ | label | requirement      |
-      | TLR | label | tool-requirement |
     Then uniquely identify answer concepts
-      | x   |
-      | REQ |
-      | TLR |
+      | x                      |
+      | label:requirement      |
+      | label:tool-requirement |
 
 
   Scenario: an abstract relation type can be defined as a subtype of a concrete relation type
@@ -1324,12 +1144,9 @@ Feature: Graql Define Query
       """
       match $x sub requirement; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value            |
-      | TCR | label | tech-requirement |
     Then uniquely identify answer concepts
-      | x   |
-      | TCR |
+      | x                      |
+      | label:tech-requirement |
 
 
   Scenario: an abstract attribute type can be defined
@@ -1344,12 +1161,9 @@ Feature: Graql Define Query
       """
       match $x type number-of-limbs; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value           |
-      | NOL | label | number-of-limbs |
     Then uniquely identify answer concepts
-      | x   |
-      | NOL |
+      | x                     |
+      | label:number-of-limbs |
 
 
   Scenario: a concrete attribute type can be defined as a subtype of an abstract attribute type
@@ -1366,14 +1180,10 @@ Feature: Graql Define Query
       """
       match $x sub number-of-limbs;
       """
-    When concept identifiers are
-      |     | check | value           |
-      | NOL | label | number-of-limbs |
-      | NLE | label | number-of-legs  |
     Then uniquely identify answer concepts
-      | x   |
-      | NOL |
-      | NLE |
+      | x                     |
+      | label:number-of-limbs |
+      | label:number-of-legs  |
 
 
   Scenario: an abstract attribute type can be defined as a subtype of another abstract attribute type
@@ -1390,14 +1200,10 @@ Feature: Graql Define Query
       """
       match $x sub number-of-limbs; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value                      |
-      | NOL | label | number-of-limbs            |
-      | NAL | label | number-of-artificial-limbs |
     Then uniquely identify answer concepts
-      | x   |
-      | NOL |
-      | NAL |
+      | x                     |
+      | label:number-of-limbs |
+      | label:number-of-legs  |
 
 
   Scenario: defining attribute type hierarchies is idempotent
@@ -1497,14 +1303,10 @@ Feature: Graql Define Query
       """
       match $x owns name;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | PER | label | person     |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | EMP |
+      | x                |
+      | label:person     |
+      | label:employment |
 
 
   Scenario: a new playable role can be defined on an existing type
@@ -1519,14 +1321,10 @@ Feature: Graql Define Query
       """
       match $x plays employment:employee;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | PER | label | person     |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | EMP |
+      | x                |
+      | label:person     |
+      | label:employment |
 
 
   Scenario: defining a key on an existing type is possible if existing instances have it and there are no collisions
@@ -1564,12 +1362,9 @@ Feature: Graql Define Query
       """
       match $x owns barcode @key;
       """
-    When concept identifiers are
-      |     | check | value   |
-      | PRD | label | product |
     Then uniquely identify answer concepts
-      | x   |
-      | PRD |
+      | x             |
+      | label:product |
 
 
   Scenario: defining a key on a type throws if existing instances don't have that key
@@ -1648,12 +1443,9 @@ Feature: Graql Define Query
       """
       match $x relates employer;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x                |
+      | label:employment |
 
 
   Scenario: a regex constraint can be added to an existing attribute type if all its instances satisfy it
@@ -1681,12 +1473,9 @@ Feature: Graql Define Query
       """
       match $x regex "^A.*$";
       """
-    When concept identifiers are
-      |     | check | value |
-      | NAM | label | name  |
     Then uniquely identify answer concepts
-      | x   |
-      | NAM |
+      | x          |
+      | label:name |
 
 
   Scenario: a regex cannot be added to an existing attribute type if there is an instance that doesn't satisfy it
@@ -1761,12 +1550,9 @@ Feature: Graql Define Query
       """
       match $x owns name @key;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: defining a rule is idempotent
@@ -1815,12 +1601,9 @@ Feature: Graql Define Query
       """
       match $x sub person; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: a concrete relation type can be converted to an abstract relation type
@@ -1835,12 +1618,9 @@ Feature: Graql Define Query
       """
       match $x sub employment; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x                |
+      | label:employment |
 
 
   Scenario: a concrete attribute type can be converted to an abstract attribute type
@@ -1855,12 +1635,9 @@ Feature: Graql Define Query
       """
       match $x sub name; $x abstract;
       """
-    When concept identifiers are
-      |     | check | value |
-      | NAM | label | name  |
     Then uniquely identify answer concepts
-      | x   |
-      | NAM |
+      | x          |
+      | label:name |
 
 
   Scenario: an existing entity type cannot be converted to abstract if it has existing instances
@@ -1944,14 +1721,10 @@ Feature: Graql Define Query
       """
       match $x sub apple-product;
       """
-    When concept identifiers are
-      |     | check | value         |
-      | APL | label | apple-product |
-      | GEN | label | genius        |
     Then uniquely identify answer concepts
-      | x   |
-      | APL |
-      | GEN |
+      | x                   |
+      | label:apple-product |
+      | label:genius        |
 
 
   Scenario: an existing relation type can be switched to a new supertype
@@ -1992,12 +1765,9 @@ Feature: Graql Define Query
       """
       match $x sub shoe-size;
       """
-    When concept identifiers are
-      |     | check | value     |
-      | SHS | label | shoe-size |
     Then uniquely identify answer concepts
-      | x   |
-      | SHS |
+      | x               |
+      | label:shoe-size |
 
 
   Scenario: assigning a new supertype succeeds even if they have different attributes + roles, if there are no instances
@@ -2025,16 +1795,11 @@ Feature: Graql Define Query
       """
       match $x sub organism;
       """
-    When concept identifiers are
-      |     | check | value    |
-      | ORG | label | organism |
-      | PER | label | person   |
-      | CHI | label | child    |
     Then uniquely identify answer concepts
-      | x   |
-      | ORG |
-      | PER |
-      | CHI |
+      | x              |
+      | label:organism |
+      | label:person   |
+      | label:child    |
 
 
   Scenario: assigning a new supertype succeeds even with existing data if the supertypes have no properties
@@ -2071,12 +1836,9 @@ Feature: Graql Define Query
       """
       match $x sub pigeon;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PIG | label | pigeon |
     Then uniquely identify answer concepts
-      | x   |
-      | PIG |
+      | x            |
+      | label:pigeon |
 
 
   Scenario: assigning a new supertype succeeds with existing data if the supertypes play the same roles
@@ -2114,12 +1876,9 @@ Feature: Graql Define Query
       """
       match $x sub pigeon;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PIG | label | pigeon |
     Then uniquely identify answer concepts
-      | x   |
-      | PIG |
+      | x            |
+      | label:pigeon |
 
 
   Scenario: assigning a new supertype succeeds with existing data if the supertypes have the same attributes
@@ -2157,12 +1916,9 @@ Feature: Graql Define Query
       """
       match $x sub pigeon;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PIG | label | pigeon |
     Then uniquely identify answer concepts
-      | x   |
-      | PIG |
+      | x            |
+      | label:pigeon |
 
 
   # TODO: write this once 'assign new supertype .. with existing data' succeeds if the supertypes have the same attributes
@@ -2205,17 +1961,11 @@ Feature: Graql Define Query
       """
       match $x type child, plays $r;
       """
-    When concept identifiers are
-      |          | check | value    |
-      | EMPLOYEE | label | employee |
-      | EMPLOYER | label | employer |
-      | EARNER   | label | earner   |
-      | CHILD    | label | child    |
     Then uniquely identify answer concepts
-      | x     | r        |
-      | CHILD | EMPLOYEE |
-      | CHILD | EMPLOYER |
-      | CHILD | EARNER   |
+      | x           | r              |
+      | label:child | label:employee |
+      | label:child | label:employer |
+      | label:child | label:earner   |
 
 
   Scenario: when adding an attribute ownership to an existing type, the change is propagated to its subtypes
@@ -2233,15 +1983,10 @@ Feature: Graql Define Query
       """
       match $x type child, owns $y;
       """
-    When concept identifiers are
-      |       | check | value        |
-      | CHILD | label | child        |
-      | NAME  | label | name         |
-      | PHONE | label | phone-number |
     Then uniquely identify answer concepts
-      | x     | y     |
-      | CHILD | NAME  |
-      | CHILD | PHONE |
+      | x           | y                  |
+      | label:child | label:name         |
+      | label:child | label:phone-number |
 
 
   Scenario: when adding a key ownership to an existing type, the change is propagated to its subtypes
@@ -2259,14 +2004,10 @@ Feature: Graql Define Query
       """
       match $x type child, owns $y @key;
       """
-    When concept identifiers are
-      |       | check | value |
-      | CHILD | label | child |
-      | EMAIL | label | email |
     Then uniquely identify answer concepts
-      | x     | y     |
-      | CHILD | EMAIL |
-      | CHILD | EMAIL |
+      | x           | y           |
+      | label:child | label:email |
+      | label:child | label:email |
 
 
   Scenario: when adding a related role to an existing relation type, the change is propagated to all its subtypes
@@ -2283,15 +2024,10 @@ Feature: Graql Define Query
       """
       match $x type part-time-employment, relates $r;
       """
-    When concept identifiers are
-      |           | check | value                |
-      | EMPLOYEE  | label | employee             |
-      | EMPLOYER  | label | employer             |
-      | PART_TIME | label | part-time-employment |
     Then uniquely identify answer concepts
-      | x         | r        |
-      | PART_TIME | EMPLOYEE |
-      | PART_TIME | EMPLOYER |
+      | x                          | r              |
+      | label:part-time-employment | label:employee |
+      | label:part-time-employment | label:employer |
 
 
   ####################
@@ -2347,12 +2083,9 @@ Feature: Graql Define Query
       """
       match $x relates function; $x plays recursive-function:function;
       """
-    When concept identifiers are
-      |     | check | value              |
-      | REC | label | recursive-function |
     Then uniquely identify answer concepts
-      | x   |
-      | REC |
+      | x                        |
+      | label:recursive-function |
 
 
   Scenario: an attribute type can own itself
@@ -2367,12 +2100,9 @@ Feature: Graql Define Query
       """
       match $x owns number-of-letters;
       """
-    When concept identifiers are
-      |     | check | value             |
-      | NOL | label | number-of-letters |
     Then uniquely identify answer concepts
-      | x   |
-      | NOL |
+      | x                       |
+      | label:number-of-letters |
 
 
   Scenario: two relation types in a type hierarchy can play each other's roles

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -110,7 +110,6 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
@@ -595,11 +594,6 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -1110,7 +1104,6 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
     Then uniquely identify answer concepts
       | x                 |
       | key:name:Sherlock |

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -60,17 +60,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
-      | JOHN | value | name:John |
-      | nALX | value | name:Alex |
-      | nBOB | value | name:Bob  |
     Given uniquely identify answer concepts
-      | x    | y   | r  | n    |
-      | ALEX | BOB | FR | JOHN |
+      | x             | y            | r         | n               |
+      | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -89,8 +81,8 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
+      | x            |
+      | key:name:Bob |
     When get answers of graql query
       """
       match $x isa friendship;
@@ -101,9 +93,9 @@ Feature: Graql Delete Query
       match $x isa name;
       """
     Then uniquely identify answer concepts
-      | x    |
-      | nALX |
-      | nBOB |
+      | x               |
+      | value:name:Alex |
+      | value:name:Bob  |
 
 
   Scenario: an instance can be deleted using the 'thing' meta label
@@ -119,14 +111,9 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
-      | JOHN | value | name:John |
     Then uniquely identify answer concepts
-      | x    | y   | r  | n    |
-      | ALEX | BOB | FR | JOHN |
+      | x             | y            | r         | n               |
+      | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -143,8 +130,8 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
+      | x            |
+      | key:name:Bob |
 
 
   Scenario: an entity can be deleted using the 'entity' meta label
@@ -159,15 +146,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
-      | JOHN | value | name:John |
     Then uniquely identify answer concepts
-      | x    | y   | r  | n    |
-      | ALEX | BOB | FR | JOHN |
+      | x             | y            | r         | n               |
+      | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -184,8 +165,8 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
+      | x            |
+      | key:name:Bob |
 
 
   Scenario: a relation can be deleted using the 'relation' meta label
@@ -200,15 +181,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
-      | JOHN | value | name:John |
     Then uniquely identify answer concepts
-      | x    | y   | r  | n    |
-      | ALEX | BOB | FR | JOHN |
+      | x             | y            | r         | n               |
+      | key:name:Alex | key:name:Bob | ket:ref:0 | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -235,12 +210,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | JOHN | value | name:John |
     Then uniquely identify answer concepts
-      | n    |
-      | JOHN |
+      | n               |
+      | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -271,15 +243,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
-      | JOHN | value | name:John |
     Then uniquely identify answer concepts
-      | x    | y   | r  | n    |
-      | ALEX | BOB | FR | JOHN |
+      | x             | y            | r         | n               |
+      | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -296,8 +262,8 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
+      | x              |
+      | value:name:Bob |
 
 
   Scenario: one delete statement can delete multiple things
@@ -309,13 +275,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |     | check | value        |
-      | ALC | key   | name:Alice   |
-      | BAR | key   | name:Barbara |
     Then uniquely identify answer concepts
-      | a   | b   |
-      | ALC | BAR |
+      | a              | b                |
+      | key:name:Alice | key:name:Barbara |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -424,15 +386,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value       |
-      | ALEX | key   | name:Alex   |
-      | BOB  | key   | name:Bob    |
-      | CAR  | key   | name:Carrie |
-      | FR   | key   | ref:0       |
     Then uniquely identify answer concepts
-      | x    | y   | z   | r  |
-      | ALEX | BOB | CAR | FR |
+      | x             | y            | z               | r         |
+      | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -452,9 +408,9 @@ Feature: Graql Delete Query
       match (friend: $x, friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | x   | y   |
-      | BOB | CAR |
-      | CAR | BOB |
+      | x               | y               |
+      | key:name:Bob    | key:name:Carrie |
+      | key:name:Carrie | key:name:Bob    |
 
 
   Scenario: deleting a role player from a relation using meta 'role' removes the player from the relation
@@ -469,15 +425,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value       |
-      | ALEX | key   | name:Alex   |
-      | BOB  | key   | name:Bob    |
-      | CAR  | key   | name:Carrie |
-      | FR   | key   | ref:0       |
     Then uniquely identify answer concepts
-      | x    | y   | z   | r  |
-      | ALEX | BOB | CAR | FR |
+      | x             | y            | z               | r         |
+      | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
     Given session opens transaction of type: write
     When graql delete
       """
@@ -497,9 +447,9 @@ Feature: Graql Delete Query
       match (friend: $x, friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | x   | y   |
-      | BOB | CAR |
-      | CAR | BOB |
+      | x               | y               |
+      | key:name:Bob    | key:name:Carrie |
+      | key:name:Carrie | key:name:Bob    |
 
 
   Scenario: deleting a role player from a relation using a super-role removes the player from the relation
@@ -529,15 +479,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value       |
-      | ALEX | key   | name:Alex   |
-      | BOB  | key   | name:Bob    |
-      | CAR  | key   | name:Carrie |
-      | FR   | key   | ref:0       |
     Then uniquely identify answer concepts
-      | x    | y   | z   | r  |
-      | ALEX | BOB | CAR | FR |
+      | x             | y            | z               | r         |
+      | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -557,9 +501,9 @@ Feature: Graql Delete Query
       match (special-friend: $x, special-friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | x   | y   |
-      | BOB | CAR |
-      | CAR | BOB |
+      | x               | y               |
+      | key:name:Bob    | key:name:Carrie |
+      | key:name:Carrie | key:name:Bob    |
 
 
   Scenario: deleting an instance removes it from all relations
@@ -574,16 +518,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value       |
-      | ALEX | key   | name:Alex   |
-      | BOB  | key   | name:Bob    |
-      | CAR  | key   | name:Carrie |
-      | FR1  | key   | ref:1       |
-      | FR2  | key   | ref:2       |
     Then uniquely identify answer concepts
-      | x    | y   | z   | r   | r2  |
-      | ALEX | BOB | CAR | FR1 | FR2 |
+      | x             | y            | z               | r         | r2        |
+      | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:1 | key:ref:2 |
     Then the integrity is validated
     When session opens transaction of type: write
     When graql delete
@@ -602,17 +539,17 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
-      | CAR |
+      | x               |
+      | key:name:Bob    |
+      | key:name:Carrie |
     When get answers of graql query
       """
       match $r (friend: $x) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r   | x   |
-      | FR1 | BOB |
-      | FR2 | CAR |
+      | r         | x               |
+      | key:ref:1 | key:name:Bob    |
+      | key:ref:2 | key:name:Carrie |
 
 
   Scenario: duplicate role players can be deleted from a relation
@@ -625,14 +562,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -649,8 +581,8 @@ Feature: Graql Delete Query
       match $r (friend: $x) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r  | x   |
-      | FR | BOB |
+      | r         | x            |
+      | key:ref:0 | key:name:Bob |
 
 
   Scenario: when deleting multiple duplicate role players from a relation, it removes the number you asked to delete
@@ -669,8 +601,8 @@ Feature: Graql Delete Query
       | BOB  | key   | name:Bob  |
       | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -687,9 +619,9 @@ Feature: Graql Delete Query
       match $r (friend: $x, friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r  | x    | y    |
-      | FR | BOB  | ALEX |
-      | FR | ALEX | BOB  |
+      | r         | x             | y             |
+      | key:ref:0 | key:name:Bob  | key:name:Alex |
+      | key:ref:0 | key:name:Alex | key:name:Bob  |
 
 
   Scenario: when deleting duplicate role players in multiple statements, it removes the total number you asked to delete
@@ -702,14 +634,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -728,9 +655,9 @@ Feature: Graql Delete Query
       match $r (friend: $x, friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r  | x    | y    |
-      | FR | BOB  | ALEX |
-      | FR | ALEX | BOB  |
+      | r         | x             | y             |
+      | key:ref:0 | key:name:Bob  | key:name:Alex |
+      | key:ref:0 | key:name:Alex | key:name:Bob  |
 
 
   Scenario: when deleting one of the duplicate role players from a relation, only one duplicate is removed

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -670,14 +670,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -695,9 +690,9 @@ Feature: Graql Delete Query
       match $r (friend: $x, friend: $y) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r  | x    | y    |
-      | FR | BOB  | ALEX |
-      | FR | ALEX | BOB  |
+      | r         | x             | y             |
+      | key:ref:0 | key:name:Bob  | key:name:Alex |
+      | key:ref:0 | key:name:Alex | key:name:Bob  |
 
 
   Scenario: when deleting role players in multiple statements, they are all deleted
@@ -711,15 +706,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value       |
-      | ALEX | key   | name:Alex   |
-      | BOB  | key   | name:Bob    |
-      | CAR  | key   | name:Carrie |
-      | FR   | key   | ref:0       |
     Then uniquely identify answer concepts
-      | x    | y   | z   | r  |
-      | ALEX | BOB | CAR | FR |
+      | x             | y            | z               | r         |
+      | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -740,8 +729,8 @@ Feature: Graql Delete Query
       match $r (friend: $x) isa friendship;
       """
     Then uniquely identify answer concepts
-      | r  | x   |
-      | FR | CAR |
+      | r         | x               |
+      | key:ref:0 | key:name:Carrie |
 
 
   Scenario: when deleting more role players than actually exist, an error is thrown
@@ -777,14 +766,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -815,14 +799,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value     |
-      | ALEX | key   | name:Alex |
-      | BOB  | key   | name:Bob  |
-      | FR   | key   | ref:0     |
     Then uniquely identify answer concepts
-      | x    | y   | r  |
-      | ALEX | BOB | FR |
+      | x             | y            | r         |
+      | key:name:Alex | key:name:Bob | key:ref:0 |
     When session opens transaction of type: write
     When graql delete
       """
@@ -971,13 +950,9 @@ Feature: Graql Delete Query
       """
       match $rel (chef: $p) isa ship-crew;
       """
-    When concept identifiers are
-      |      | check | value       |
-      | CREW | key   | ref:0       |
-      | JOSH | key   | name:Joshua |
     Then uniquely identify answer concepts
-      | rel  | p    |
-      | CREW | JOSH |
+      | rel       | p               |
+      | key:ref:0 | key:name:Joshua |
     When graql delete
       """
       match
@@ -1026,12 +1001,9 @@ Feature: Graql Delete Query
       """
       match $x has age 18;
       """
-    When concept identifiers are
-      |     | check | value     |
-      | ANA | key   | name:Anna |
     Then uniquely identify answer concepts
-      | x   |
-      | ANA |
+      | x             |
+      | key:name:Anna |
     When graql delete
       """
       match
@@ -1076,16 +1048,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    When concept identifiers are
-      |      | check | value          |
-      | ALEX | key   | name:Alex      |
-      | JOHN | key   | name:John      |
-      | lnST | value | lastname:Smith |
-      | nALX | value | name:Alex      |
-      | nJHN | value | name:John      |
     Then uniquely identify answer concepts
-      | x    | y    |
-      | ALEX | JOHN |
+      | x             | y             |
+      | key:name:Alex | key:name:John |
     When session opens transaction of type: write
     When graql delete
       """
@@ -1103,23 +1068,23 @@ Feature: Graql Delete Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x    |
-      | ALEX |
-      | JOHN |
+      | x             |
+      | key:name:Alex |
+      | key:name:John |
     When get answers of graql query
       """
       match $n isa lastname;
       """
     Then uniquely identify answer concepts
-      | n    |
-      | lnST |
+      | n                    |
+      | value:lastname:Smith |
     When get answers of graql query
       """
       match $x isa person, has lastname $n;
       """
     Then uniquely identify answer concepts
-      | x    | n    |
-      | JOHN | lnST |
+      | x             | n                    |
+      | key:name:John | value:lastname:Smith |
 
 
   Scenario: an attribute ownership can be deleted using the 'attribute' meta label
@@ -1146,22 +1111,18 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     Given concept identifiers are
-      |      | check | value           |
-      | SHER | key   | name:Sherlock   |
-      | nSLK | value | name:Sherlock   |
-      | pcW1 | value | postcode:W1U8ED |
     Then uniquely identify answer concepts
-      | x    |
-      | SHER |
+      | x                 |
+      | key:name:Sherlock |
     When session opens transaction of type: write
     When get answers of graql query
       """
       match $x has attribute $a;
       """
     Then uniquely identify answer concepts
-      | x    | a    |
-      | SHER | nSLK |
-      | SHER | pcW1 |
+      | x                 | a                     |
+      | key:name:Sherlock | value:name:Sherlock   |
+      | key:name:Sherlock | value:postcode:W1U8ED |
     When graql delete
       """
       match
@@ -1178,8 +1139,8 @@ Feature: Graql Delete Query
       match $x has attribute $a;
       """
     Then uniquely identify answer concepts
-      | x    | a    |
-      | SHER | nSLK |
+      | x                 | a                   |
+      | key:name:Sherlock | value:name:Sherlock |
 
 
   Scenario: an attribute ownership can be deleted using its supertype as a label
@@ -1205,19 +1166,14 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
-      |      | check | value           |
-      | SHER | key   | name:Sherlock   |
-      | nSLK | value | name:Sherlock   |
-      | pcW1 | value | postcode:W1U8ED |
     When session opens transaction of type: write
     When get answers of graql query
       """
       match $x has address $a;
       """
     Then uniquely identify answer concepts
-      | x    | a    |
-      | SHER | pcW1 |
+      | x                 | a                     |
+      | key:name:Sherlock | value:postcode:W1U8ED |
     When graql delete
       """
       match
@@ -1277,13 +1233,9 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
-      |     | check | value       |
-      | WAT | key   | name:Watson |
-      | nWA | value | name:Watson |
     Then uniquely identify answer concepts
-      | x   |
-      | WAT |
+      | x               |
+      | key:name:Watson |
     When session opens transaction of type: write
     When graql delete
       """
@@ -1350,13 +1302,9 @@ Feature: Graql Delete Query
       """
       match $x has duration $d;
       """
-    When concept identifiers are
-      |      | check | value         |
-      | REF0 | key   | ref:0         |
-      | DURA | value | duration:1000 |
     Then uniquely identify answer concepts
-      | x    | d    |
-      | REF0 | DURA |
+      | x         | d                   |
+      | key:ref:0 | value:duration:1000 |
     When graql delete
       """
       match
@@ -1402,13 +1350,9 @@ Feature: Graql Delete Query
       """
       match $x has duration $d;
       """
-    When concept identifiers are
-      |      | check | value         |
-      | REF0 | key   | ref:0         |
-      | DURA | value | duration:1000 |
     Then uniquely identify answer concepts
-      | x    | d    |
-      | REF0 | DURA |
+      | x         | d                   |
+      | key:ref:0 | value:duration:1000 |
     When graql delete
       """
       match
@@ -1476,16 +1420,6 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
-      |      | check | value          |
-      | ALEX | key   | name:Alex      |
-      | JOHN | key   | name:John      |
-      | SMTH | value | lastname:Smith |
-      | nALX | value | name:Alex      |
-      | nJHN | value | name:John      |
-      | F1   | key   | ref:1          |
-      | F2   | key   | ref:2          |
-      | REFL | key   | ref:3          |
     When session opens transaction of type: write
     When graql delete
       """
@@ -1507,25 +1441,25 @@ Feature: Graql Delete Query
       match $f (friend: $x) isa friendship;
       """
     Then uniquely identify answer concepts
-      | f    | x    |
-      | F2   | ALEX |
-      | F2   | JOHN |
-      | REFL | ALEX |
+      | f           | x             |
+      | key:ref:1   | key:name:Alex |
+      | key:ref:2   | key:name:John |
+      | key:ref:3   | key:name:Alex |
     When get answers of graql query
       """
       match $n isa name;
       """
     Then uniquely identify answer concepts
-      | n    |
-      | nJHN |
-      | nALX |
+      | n               |
+      | value:name:John |
+      | value:name:Alex |
     When get answers of graql query
       """
       match $x isa person, has lastname $n;
       """
     Then uniquely identify answer concepts
-      | x    | n    |
-      | JOHN | SMTH |
+      | x             | n                    |
+      | key:name:John | value:lastname:Smith |
 
 
   Scenario: deleting everything in a complex pattern
@@ -1558,16 +1492,6 @@ Feature: Graql Delete Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given concept identifiers are
-      |      | check | value          |
-      | ALEX | key   | name:Alex      |
-      | JOHN | key   | name:John      |
-      | SMTH | value | lastname:Smith |
-      | nALX | value | name:Alex      |
-      | nJHN | value | name:John      |
-      | F1   | key   | ref:1          |
-      | F2   | key   | ref:2          |
-      | REFL | key   | ref:3          |
     When session opens transaction of type: write
     When graql delete
       """
@@ -1639,12 +1563,9 @@ Feature: Graql Delete Query
       """
       match $x isa name;
       """
-    When concept identifiers are
-      |     | check | value        |
-      | TAT | value | name:Tatyana |
     Then uniquely identify answer concepts
-      | x   |
-      | TAT |
+      | x                  |
+      | value:name:Tatyana |
     Then graql delete; throws exception
       """
       match

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -71,11 +71,6 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    And concept identifiers are
-      |     | check | value     |
-      | PER | key   | ref:0     |
-      | LIS | value | name:Lisa |
-      | SIX | value | age:16    |
     When get answers of graql query
       """
       match
@@ -83,8 +78,8 @@ Feature: Graql Get Clause
       get $z, $x;
       """
     Then uniquely identify answer concepts
-      | z   | x   |
-      | PER | LIS |
+      | z         | x               |
+      | key:ref:0 | value:name:Lisa |
 
 
   Scenario: when a 'get' has unbound variables, an error is thrown
@@ -420,15 +415,10 @@ Feature: Graql Get Clause
       sort $y asc;
       limit 2;
       """
-    And concept identifiers are
-      |      | check | value |
-      | A2P1 | key   | ref:0 |
-      | A2P2 | key   | ref:4 |
-      | AGE2 | value | age:2 |
     Then uniquely identify answer concepts
-      | x    | y    |
-      | A2P1 | AGE2 |
-      | A2P2 | AGE2 |
+      | x         | y           |
+      | key:ref:0 | value:age:2 |
+      | key:ref:4 | value:age:2 |
     When get answers of graql query
       """
       match $x isa person, has age $y;
@@ -442,9 +432,9 @@ Feature: Graql Get Clause
       | A6P2 | key   | ref:3 |
       | AGE6 | value | age:6 |
     Then uniquely identify answer concepts
-      | x    | y    |
-      | A6P1 | AGE6 |
-      | A6P2 | AGE6 |
+      | x         | y           |
+      | key:ref:1 | value:age:6 |
+      | key:ref:3 | value:age:6 |
 
 
   Scenario: when sorting by a variable not contained in the answer set, an error is thrown
@@ -850,19 +840,19 @@ Feature: Graql Get Clause
       | BER | key   | ref:2 |
       | COL | key   | ref:3 |
     Then uniquely identify answer concepts
-      | x   | y   |
-      | VIO | RUP |
-      | VIO | BER |
-      | VIO | COL |
-      | RUP | VIO |
-      | RUP | BER |
-      | RUP | COL |
-      | BER | VIO |
-      | BER | RUP |
-      | BER | COL |
-      | COL | VIO |
-      | COL | RUP |
-      | COL | BER |
+      | x         | y         |
+      | key:ref:0 | key:ref:1 |
+      | key:ref:0 | key:ref:2 |
+      | key:ref:0 | key:ref:3 |
+      | key:ref:1 | key:ref:0 |
+      | key:ref:1 | key:ref:2 |
+      | key:ref:1 | key:ref:3 |
+      | key:ref:2 | key:ref:0 |
+      | key:ref:2 | key:ref:1 |
+      | key:ref:2 | key:ref:3 |
+      | key:ref:3 | key:ref:0 |
+      | key:ref:3 | key:ref:1 |
+      | key:ref:3 | key:ref:2 |
     When get answers of graql query
       """
       match ($x, $y) isa friendship;
@@ -990,13 +980,13 @@ Feature: Graql Get Clause
       get $x, $y, $z;
       """
     Then uniquely identify answer concepts
-      | x   | y   | z   |
-      | APP | ELE | FLY |
-      | APP | ELE | LYU |
-      | APP | FLY | ELE |
-      | APP | FLY | LYU |
-      | GOO | LYU | ELE |
-      | GOO | LYU | FLY |
+      | x         | y         | z         |
+      | key:ref:0 | key:ref:2 | key:ref:3 |
+      | key:ref:0 | key:ref:2 | key:ref:4 |
+      | key:ref:0 | key:ref:3 | key:ref:2 |
+      | key:ref:0 | key:ref:3 | key:ref:4 |
+      | key:ref:1 | key:ref:4 | key:ref:2 |
+      | key:ref:1 | key:ref:4 | key:ref:3 |
     Then get answers of graql query
       """
       match

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -124,18 +124,12 @@ Feature: Graql Get Clause
       match $x isa <attr>;
       sort $x asc;
       """
-    And concept identifiers are
-      |      | check | value |
-      | VAL1 | key   | ref:0 |
-      | VAL2 | key   | ref:1 |
-      | VAL3 | key   | ref:2 |
-      | VAL4 | key   | ref:3 |
     Then order of answer concepts is
-      | x    |
-      | VAL4 |
-      | VAL2 |
-      | VAL3 |
-      | VAL1 |
+      | x         |
+      | key:ref:3 |
+      | key:ref:1 |
+      | key:ref:2 |
+      | key:ref:0 |
 
     Examples:
       | attr          | type     | val4       | val2             | val3             | val1       |
@@ -162,33 +156,23 @@ Feature: Graql Get Clause
       match $x isa person, has name $y;
       sort $y asc;
       """
-    And concept identifiers are
-      |      | check | value          |
-      | GAR  | key   | ref:0          |
-      | JEM  | key   | ref:1          |
-      | FRE  | key   | ref:2          |
-      | BRE  | key   | ref:3          |
-      | nGAR | value | name:Gary      |
-      | nJEM | value | name:Jemima    |
-      | nFRE | value | name:Frederick |
-      | nBRE | value | name:Brenda    |
     Then order of answer concepts is
-      | x   | y    |
-      | BRE | nBRE |
-      | FRE | nFRE |
-      | GAR | nGAR |
-      | JEM | nJEM |
+      | x         | y                    |
+      | key:ref:3 | value:name:Brenda    |
+      | key:ref:2 | value:name:Frederick |
+      | key:ref:0 | value:name:Gary      |
+      | key:ref:1 | value:name:Jemima    |
     When get answers of graql query
       """
       match $x isa person, has name $y;
       sort $y desc;
       """
     Then order of answer concepts is
-      | x   | y    |
-      | JEM | nJEM |
-      | GAR | nGAR |
-      | FRE | nFRE |
-      | BRE | nBRE |
+      | x         | y                    |
+      | key:ref:1 | value:name:Jemima    |
+      | key:ref:0 | value:name:Gary      |
+      | key:ref:2 | value:name:Frederick |
+      | key:ref:3 | value:name:Brenda    |
 
 
   Scenario: the default sort order is ascending
@@ -208,22 +192,12 @@ Feature: Graql Get Clause
       match $x isa person, has name $y;
       sort $y;
       """
-    And concept identifiers are
-      |      | check | value          |
-      | GAR  | key   | ref:0          |
-      | JEM  | key   | ref:1          |
-      | FRE  | key   | ref:2          |
-      | BRE  | key   | ref:3          |
-      | nGAR | value | name:Gary      |
-      | nJEM | value | name:Jemima    |
-      | nFRE | value | name:Frederick |
-      | nBRE | value | name:Brenda    |
     Then order of answer concepts is
-      | x   | y    |
-      | BRE | nBRE |
-      | FRE | nFRE |
-      | GAR | nGAR |
-      | JEM | nJEM |
+      | x         | y                    |
+      | key:ref:3 | value:name:Brenda    |
+      | key:ref:2 | value:name:Frederick |
+      | key:ref:0 | value:name:Gary      |
+      | key:ref:1 | value:name:Jemima    |
 
 
   Scenario: a sorted result set can be limited to a specific size
@@ -244,19 +218,11 @@ Feature: Graql Get Clause
       sort $y asc;
       limit 3;
       """
-    And concept identifiers are
-      |      | check | value          |
-      | GAR  | key   | ref:0          |
-      | FRE  | key   | ref:2          |
-      | BRE  | key   | ref:3          |
-      | nGAR | value | name:Gary      |
-      | nFRE | value | name:Frederick |
-      | nBRE | value | name:Brenda    |
     Then order of answer concepts is
-      | x   | y    |
-      | BRE | nBRE |
-      | FRE | nFRE |
-      | GAR | nGAR |
+      | x         | y                    |
+      | key:ref:3 | value:name:Brenda    |
+      | key:ref:2 | value:name:Frederick |
+      | key:ref:0 | value:name:Gary      |
 
 
   Scenario: sorted results can be retrieved starting from a specific offset
@@ -277,16 +243,10 @@ Feature: Graql Get Clause
       sort $y asc;
       offset 2;
       """
-    And concept identifiers are
-      |      | check | value       |
-      | GAR  | key   | ref:0       |
-      | JEM  | key   | ref:1       |
-      | nGAR | value | name:Gary   |
-      | nJEM | value | name:Jemima |
     Then order of answer concepts is
-      | x   | y    |
-      | GAR | nGAR |
-      | JEM | nJEM |
+      | x         | y                    |
+      | key:ref:0 | value:name:Gary      |
+      | key:ref:1 | value:name:Jemima    |
 
 
   Scenario: 'offset' and 'limit' can be used together to restrict the answer set
@@ -308,16 +268,10 @@ Feature: Graql Get Clause
       offset 1;
       limit 2;
       """
-    And concept identifiers are
-      |      | check | value          |
-      | GAR  | key   | ref:0          |
-      | FRE  | key   | ref:2          |
-      | nGAR | value | name:Gary      |
-      | nFRE | value | name:Frederick |
     Then order of answer concepts is
-      | x   | y    |
-      | FRE | nFRE |
-      | GAR | nGAR |
+      | x         | y                    |
+      | key:ref:2 | value:name:Frederick |
+      | key:ref:0 | value:name:Gary      |
 
 
   Scenario: when the answer size is limited to 0, an empty answer set is returned
@@ -375,25 +329,18 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When concept identifiers are
-      |     | check | value             |
-      | BON | value | name:Bond         |
-      | JAM | value | name:James Bond   |
-      | 007 | value | name:007          |
-      | AGE | value | name:agent        |
-      | SEC | value | name:secret agent |
     Then get answers of graql query
       """
       match $x isa name;
       sort $x asc;
       """
     Then order of answer concepts is
-      | x   |
-      | 007 |
-      | AGE |
-      | BON |
-      | JAM |
-      | SEC |
+      | x                       |
+      | value:name:007          |
+      | value:name:agent        |
+      | value:name:Bond         |
+      | value:name:James Bond   |
+      | value:name:secret agent |
 
 
   Scenario: sort is able to correctly handle duplicates in the value set
@@ -426,11 +373,6 @@ Feature: Graql Get Clause
       offset 2;
       limit 2;
       """
-    And concept identifiers are
-      |      | check | value |
-      | A6P1 | key   | ref:1 |
-      | A6P2 | key   | ref:3 |
-      | AGE6 | value | age:6 |
     Then uniquely identify answer concepts
       | x         | y           |
       | key:ref:1 | value:age:6 |
@@ -833,12 +775,6 @@ Feature: Graql Get Clause
       """
       match ($x, $y) isa friendship;
       """
-    And concept identifiers are
-      |     | check | value |
-      | VIO | key   | ref:0 |
-      | RUP | key   | ref:1 |
-      | BER | key   | ref:2 |
-      | COL | key   | ref:3 |
     Then uniquely identify answer concepts
       | x         | y         |
       | key:ref:0 | key:ref:1 |
@@ -858,26 +794,20 @@ Feature: Graql Get Clause
       match ($x, $y) isa friendship;
       group $x;
       """
-    And group identifiers are
-      |      | owner |
-      | gVIO | VIO   |
-      | gRUP | RUP   |
-      | gBER | BER   |
-      | gCOL | COL   |
     Then answer groups are
-      | group | x   | y   |
-      | gVIO  | VIO | RUP |
-      | gVIO  | VIO | BER |
-      | gVIO  | VIO | COL |
-      | gRUP  | RUP | VIO |
-      | gRUP  | RUP | BER |
-      | gRUP  | RUP | COL |
-      | gBER  | BER | VIO |
-      | gBER  | BER | RUP |
-      | gBER  | BER | COL |
-      | gCOL  | COL | VIO |
-      | gCOL  | COL | RUP |
-      | gCOL  | COL | BER |
+      | owner      | x         | y         |
+      | key:ref:0  | key:ref:0 | key:ref:1 |
+      | key:ref:0  | key:ref:0 | key:ref:2 |
+      | key:ref:0  | key:ref:0 | key:ref:3 |
+      | key:ref:1  | key:ref:1 | key:ref:0 |
+      | key:ref:1  | key:ref:1 | key:ref:2 |
+      | key:ref:1  | key:ref:1 | key:ref:3 |
+      | key:ref:2  | key:ref:2 | key:ref:0 |
+      | key:ref:2  | key:ref:2 | key:ref:1 |
+      | key:ref:2  | key:ref:2 | key:ref:3 |
+      | key:ref:3  | key:ref:3 | key:ref:0 |
+      | key:ref:3  | key:ref:3 | key:ref:1 |
+      | key:ref:3  | key:ref:3 | key:ref:2 |
 
 
   Scenario: when grouping answers by a variable that is not contained in the answer set, an error is thrown
@@ -921,30 +851,18 @@ Feature: Graql Get Clause
       """
       match $x isa person;
       """
-    And concept identifiers are
-      |     | check | value |
-      | VIO | key   | ref:0 |
-      | RUP | key   | ref:1 |
-      | BER | key   | ref:2 |
-      | COL | key   | ref:3 |
     When get answers of graql query
       """
       match ($x, $y) isa friendship;
       group $x;
       count;
       """
-    And group identifiers are
-      |      | owner |
-      | gVIO | VIO   |
-      | gRUP | RUP   |
-      | gBER | BER   |
-      | gCOL | COL   |
     Then group aggregate values are
-      | group | value |
-      | gVIO  | 3     |
-      | gRUP  | 3     |
-      | gBER  | 3     |
-      | gCOL  | 3     |
+      | owner      | value |
+      | key:ref:0  | 3     |
+      | key:ref:1  | 3     |
+      | key:ref:2  | 3     |
+      | key:ref:3  | 3     |
 
 
   Scenario: the size of answer groups is still computed correctly when restricting variables with 'get'
@@ -962,13 +880,6 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    And concept identifiers are
-      |     | check | value |
-      | APP | key   | ref:0 |
-      | GOO | key   | ref:1 |
-      | ELE | key   | ref:2 |
-      | FLY | key   | ref:3 |
-      | LYU | key   | ref:4 |
     When get answers of graql query
       """
       match
@@ -999,14 +910,10 @@ Feature: Graql Get Clause
       group $x;
       count;
       """
-    And group identifiers are
-      |      | owner |
-      | gAPP | APP   |
-      | gGOO | GOO   |
     Then group aggregate values are
-      | group | value |
-      | gAPP  | 4     |
-      | gGOO  | 2     |
+      | owner      | value |
+      | key:ref:0  | 4     |
+      | key:ref:1  | 2     |
 
 
   Scenario: the maximum value for a particular variable within each answer group can be retrieved using a group 'max'
@@ -1025,10 +932,6 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    And concept identifiers are
-      |     | check | value |
-      | LLO | key   | ref:0 |
-      | BAR | key   | ref:1 |
     When get answers of graql query
       """
       match
@@ -1038,11 +941,7 @@ Feature: Graql Get Clause
       group $x;
       max $z;
       """
-    And group identifiers are
-      |      | owner |
-      | gLLO | LLO   |
-      | gBAR | BAR   |
     Then group aggregate values are
-      | group | value |
-      | gLLO  | 57    |
-      | gBAR  | 45    |
+      | owner      | value |
+      | key:ref:0  | 57    |
+      | key:ref:1  | 45    |

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -77,12 +77,9 @@ Feature: Graql Insert Query
       """
       match $x isa person;
       """
-    When concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: one query can insert multiple things
@@ -99,14 +96,10 @@ Feature: Graql Insert Query
       """
       match $x isa person;
       """
-    When concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x    |
-      | REF0 |
-      | REF1 |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
 
 
   Scenario: when an insert has multiple statements with the same variable name, they refer to the same thing
@@ -124,26 +117,23 @@ Feature: Graql Insert Query
       """
       match $x has name "Bond";
       """
-    When concept identifiers are
-      |      | check | value |
-      | BOND | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x    |
-      | BOND |
+      | x         |
+      | key:ref:0 |
     When get answers of graql query
       """
       match $x has name "James Bond";
       """
     Then uniquely identify answer concepts
-      | x    |
-      | BOND |
+      | x         |
+      | key:ref:0 |
     When get answers of graql query
       """
       match $x has name "Bond", has name "James Bond";
       """
     Then uniquely identify answer concepts
-      | x    |
-      | BOND |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: when running multiple identical insert queries in series, new things get created each time
@@ -210,12 +200,9 @@ Feature: Graql Insert Query
       insert $x isa! person, has name "Harry", has ref 0;
       """
     Then the integrity is validated
-    When concept identifiers are
-      |     | check | value |
-      | HAR | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | HAR |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: attempting to insert an instance of an abstract type throws an error
@@ -269,18 +256,12 @@ Feature: Graql Insert Query
       """
       match $x isa thing;
       """
-    When concept identifiers are
-      |      | check | value           |
-      | WIL  | key   | ref:0           |
-      | nWIL | value | name:Wilhelmina |
-      | a25  | value | age:25          |
-      | REF0 | value | ref:0           |
     Then uniquely identify answer concepts
-      | x    |
-      | WIL  |
-      | nWIL |
-      | a25  |
-      | REF0 |
+      | x                     |
+      | key:ref:0             |
+      | value:name:Wilhelmina |
+      | value:age:25          |
+      | value:ref:0           |
 
 
   Scenario: a freshly inserted attribute has no owners
@@ -317,12 +298,9 @@ Feature: Graql Insert Query
       """
       match $x has name "Kyle";
       """
-    When concept identifiers are
-      |      | check | value |
-      | KYLE | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x    |
-      | KYLE |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: after inserting two things that own the same attribute, the attribute has two owners
@@ -343,14 +321,10 @@ Feature: Graql Insert Query
       not { $p1 is $p2; };
       get $p1, $p2;
       """
-    When concept identifiers are
-      |      | check | value |
-      | JACK | key   | ref:0 |
-      | JILL | key   | ref:1 |
     Then uniquely identify answer concepts
-      | p1   | p2   |
-      | JACK | JILL |
-      | JILL | JACK |
+      | p1        | p2        |
+      | key:ref:0 | key:ref:1 |
+      | key:ref:1 | key:ref:0 |
 
 
   Scenario: after inserting a new owner for every existing ownership of an attribute, its number of owners doubles
@@ -432,14 +406,10 @@ Feature: Graql Insert Query
       """
       match $p isa person, has <attr> $x; get $x;
       """
-    When concept identifiers are
-      |      | check | value |
-      | VAL1 | key   | ref:0 |
-      | VAL2 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x    |
-      | VAL1 |
-      | VAL2 |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
 
     Examples:
       | attr              | type     | val1       | val2       |
@@ -491,12 +461,9 @@ Feature: Graql Insert Query
       """
       match $p has name "Spiderman";
       """
-    When concept identifiers are
-      |     | check | value |
-      | PET | key   | ref:0 |
     Then uniquely identify answer concepts
-      | p   |
-      | PET |
+      | p         |
+      | key:ref:0 |
 
 
   Scenario: when inserting an additional attribute ownership on an entity, the entity type can be optionally specified
@@ -527,12 +494,9 @@ Feature: Graql Insert Query
       """
       match $p has name "Spiderman";
       """
-    When concept identifiers are
-      |     | check | value |
-      | PET | key   | ref:0 |
     Then uniquely identify answer concepts
-      | p   |
-      | PET |
+      | p         |
+      | key:ref:0 |
 
 
   Scenario: when an attribute owns an attribute, an instance of that attribute can be inserted onto it
@@ -577,12 +541,9 @@ Feature: Graql Insert Query
       """
       match $c has hex-value "#FF0000";
       """
-    When concept identifiers are
-      |     | check | value      |
-      | COL | value | colour:red |
     Then uniquely identify answer concepts
-      | c   |
-      | COL |
+      | c                |
+      | value:colour:red |
 
 
   Scenario: when inserting an additional attribute ownership on an attribute, the owner type can be optionally specified
@@ -627,12 +588,9 @@ Feature: Graql Insert Query
       """
       match $c has hex-value "#FF0000";
       """
-    When concept identifiers are
-      |     | check | value      |
-      | COL | value | colour:red |
     Then uniquely identify answer concepts
-      | c   |
-      | COL |
+      | c                |
+      | value:colour:red |
 
 
   Scenario: when linking an attribute that doesn't exist yet to a relation, the attribute gets created
@@ -685,13 +643,9 @@ Feature: Graql Insert Query
       """
       match $r isa residence, has tenure-days $a; get $a;
       """
-    When concept identifiers are
-      |     | check | value           |
-      | RES | key   | ref:0           |
-      | TEN | value | tenure-days:365 |
     Then uniquely identify answer concepts
-      | a   |
-      | TEN |
+      | a                     |
+      | value:tenure-days:365 |
 
 
   Scenario: an attribute ownership currently inferred by a rule can be explicitly inserted
@@ -724,12 +678,9 @@ Feature: Graql Insert Query
       """
       match $p has age 32;
       """
-    Given concept identifiers are
-      |      | check | value |
-      | LUCY | key   | ref:0 |
     Given uniquely identify answer concepts
-      | p    |
-      | LUCY |
+      | p         |
+      | key:ref:0 |
     Given graql insert
       """
       match
@@ -745,8 +696,8 @@ Feature: Graql Insert Query
       match $p has age 32;
       """
     Then uniquely identify answer concepts
-      | p    |
-      | LUCY |
+      | p         |
+      | key:ref:0 |
 
 
   #############
@@ -767,13 +718,9 @@ Feature: Graql Insert Query
       """
       match $r (employee: $p) isa employment;
       """
-    When concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
-      | EMP | key   | ref:1 |
     Then uniquely identify answer concepts
-      | p   | r   |
-      | PER | EMP |
+      | p         | r         |
+      | key:ref:0 | key:ref:1 |
 
 
   Scenario: when inserting a relation that owns an attribute and has an attribute roleplayer, both attributes are created
@@ -812,14 +759,9 @@ Feature: Graql Insert Query
       """
       match $r (place-of-residence: $addr) isa residence, has is-permanent $perm;
       """
-    When concept identifiers are
-      |     | check | value                         |
-      | RES | key   | ref:0                         |
-      | ADD | value | address:742 Evergreen Terrace |
-      | PER | value | is-permanent:true             |
     Then uniquely identify answer concepts
-      | r   | addr | perm |
-      | RES | ADD  | PER  |
+      | r         | addr                                 | perm                     |
+      | key:ref:0 | value:address:742 Evergreen Terrace  | value:is-permanent:true  |
 
 
   Scenario: relations can be inserted with multiple role players
@@ -841,12 +783,9 @@ Feature: Graql Insert Query
         $c has name $cname;
       get $cname;
       """
-    When concept identifiers are
-      |     | check | value          |
-      | MOR | value | name:Morrisons |
     Then uniquely identify answer concepts
-      | cname |
-      | MOR   |
+      | cname                  |
+      | value:name:Morrisons   |
     When get answers of graql query
       """
       match
@@ -854,10 +793,7 @@ Feature: Graql Insert Query
         $p has name $pname;
       get $pname;
       """
-    When concept identifiers are
-      |     | check | value       |
-      | GOR | value | name:Gordon |
-      | HEL | value | name:Helen  |
+    #TODO: Appears unfinished?
 
 
   Scenario: an additional role player can be inserted onto an existing relation
@@ -883,14 +819,9 @@ Feature: Graql Insert Query
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
-    When concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
-      | REF2 | key   | ref:2 |
     Then uniquely identify answer concepts
-      | p    | c    | r    |
-      | REF0 | REF2 | REF1 |
+      | p         | c         | r         |
+      | key:ref:0 | key:ref:2 | key:ref:1 |
 
 
   Scenario: an additional role player can be inserted into every relation matching a pattern
@@ -920,16 +851,10 @@ Feature: Graql Insert Query
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
-    When concept identifiers are
-      |      | check | value |
-      | RUTH | key   | ref:0 |
-      | EMP1 | key   | ref:1 |
-      | EMP2 | key   | ref:2 |
-      | COMP | key   | ref:3 |
     Then uniquely identify answer concepts
-      | p    | c    | r    |
-      | RUTH | COMP | EMP1 |
-      | RUTH | COMP | EMP2 |
+      | p         | c         | r         |
+      | key:ref:0 | key:ref:3 | key:ref:1 |
+      | key:ref:0 | key:ref:3 | key:ref:2 |
 
 
   Scenario: an additional duplicate role player can be inserted into an existing relation
@@ -955,13 +880,9 @@ Feature: Graql Insert Query
       """
       match $r (employee: $p, employee: $p) isa employment;
       """
-    When concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | p    | r    |
-      | REF0 | REF1 |
+      | p         | r         |
+      | key:ref:0 | key:ref:1 |
 
 
   Scenario: when inserting a roleplayer that can't play the role, an error is thrown
@@ -1052,9 +973,6 @@ Feature: Graql Insert Query
       """
       match (member: $p) isa gym-membership; get $p;
       """
-    When concept identifiers are
-      |     | check | value |
-      | JEN | key   | ref:0 |
     Then graql insert
       """
       match
@@ -1070,8 +988,8 @@ Feature: Graql Insert Query
       match (member: $p) isa gym-membership; get $p;
       """
     Then uniquely identify answer concepts
-      | p   |
-      | JEN |
+      | p         |
+      | key:ref:0 |
     When get answers of graql query
       """
       match $r isa gym-membership; get $r;
@@ -1112,12 +1030,9 @@ Feature: Graql Insert Query
       """
       match $x <value> isa <attr>;
       """
-    When concept identifiers are
-      |     | check | value |
-      | ATT | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | ATT |
+      | x         |
+      | key:ref:0 |
 
     Examples:
       | attr           | type     | value      |
@@ -1165,16 +1080,13 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When concept identifiers are
-      |      | check | value |
-      | AGE2 | value | age:2 |
     When get answers of graql query
       """
       match $x isa age;
       """
     Then uniquely identify answer concepts
-      | x    |
-      | AGE2 |
+      | x           |
+      | value:age:2 |
 
 
   Scenario: inserting two 'double' attribute values with the same integer value creates a single concept
@@ -1200,17 +1112,14 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When concept identifiers are
-      |    | check | value      |
-      | L2 | value | length:2.0 |
     When get answers of graql query
       """
       match $x isa length;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
-      | x  |
-      | L2 |
+      | x                |
+      | value:length:2.0 |
 
 
   Scenario: inserting the same integer twice as a 'double' in separate transactions creates a single concept
@@ -1243,17 +1152,14 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When concept identifiers are
-      |    | check | value      |
-      | L2 | value | length:2.0 |
     When get answers of graql query
       """
       match $x isa length;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
-      | x  |
-      | L2 |
+      | x                |
+      | value:length:2.0 |
 
 
   Scenario: inserting attribute values [2] and [2.0] with the same attribute type creates a single concept
@@ -1306,19 +1212,16 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When concept identifiers are
-      |     | check | value |
-      | RF0 | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | RF0 |
+      | x         |
+      | key:ref:0 |
     When get answers of graql query
       """
       match $x <match> isa <attr>;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | RF0 |
+      | x         |
+      | key:ref:0 |
 
     Examples:
       | type     | attr       | insert           | match            |
@@ -1388,12 +1291,9 @@ Feature: Graql Insert Query
       $x 10;
       """
     Then transaction commits
-    When concept identifiers are
-      |     | check | value  |
-      | A10 | value | age:10 |
     Then uniquely identify answer concepts
-      | x   |
-      | A10 |
+      | x            |
+      | value:age:10 |
     Then the integrity is validated
 
 
@@ -1437,12 +1337,9 @@ Feature: Graql Insert Query
       """
       match $x isa person;
       """
-    When concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: when a type has a key, attempting to insert it without that key throws on commit
@@ -1512,13 +1409,9 @@ Feature: Graql Insert Query
       $z isa company, has name "Wayne Enterprises", has ref 0;
       """
     Then the integrity is validated
-    When concept identifiers are
-      |     | check | value |
-      | BRU | key   | ref:0 |
-      | WAY | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   | z   |
-      | BRU | WAY |
+      | x         | z         |
+      | key:ref:0 | key:ref:0 |
 
 
   Scenario: when inserting a thing variable with a type variable, the answer contains both variables
@@ -1530,13 +1423,9 @@ Feature: Graql Insert Query
         $x isa $type, has name "Microsoft", has ref 0;
       """
     Then the integrity is validated
-    When concept identifiers are
-      |     | check | value   |
-      | MIC | key   | ref:0   |
-      | COM | label | company |
     Then uniquely identify answer concepts
-      | x   | type |
-      | MIC | COM  |
+      | x         | type           |
+      | key:ref:0 | label:company  |
 
 
   ################
@@ -1581,10 +1470,7 @@ Feature: Graql Insert Query
       """
       match $x has is-cool true;
       """
-    When concept identifiers are
-      |     | check | value |
-      | NOR | key   | ref:0 |
-      | DAN | key   | ref:1 |
+    #TODO: Appears unfinished
 
 
   Scenario: the answers of a match-insert only include the variables referenced in the 'insert' block
@@ -1608,14 +1494,10 @@ Feature: Graql Insert Query
         (employer: $x, employee: $y) isa employment, has ref 10;
       """
     Then the integrity is validated
-    When concept identifiers are
-      |     | check | value |
-      | MIC | key   | ref:1 |
-      | TAR | key   | ref:3 |
     # Should only contain variables mentioned in the insert (so excludes '$z')
     Then uniquely identify answer concepts
-      | x   | y   |
-      | MIC | TAR |
+      | x         | y         |
+      | key:ref:1 | key:ref:3 |
 
 
   Scenario: match-insert can take an attribute's value and copy it to an attribute of a different type
@@ -1659,12 +1541,9 @@ Feature: Graql Insert Query
         $x has height $z;
       get $x;
       """
-    When concept identifiers are
-      |     | check | value |
-      | SUS | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | SUS |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: if match-insert matches nothing, then nothing is inserted
@@ -1712,14 +1591,9 @@ Feature: Graql Insert Query
       $y isa person, has name "Steven", has ref 1;
       $z isa person, has name "Theresa", has ref 2;
       """
-    Given concept identifiers are
-      |     | check | value |
-      | BEC | key   | ref:0 |
-      | STE | key   | ref:1 |
-      | THE | key   | ref:2 |
     Given uniquely identify answer concepts
-      | x   | y   | z   |
-      | BEC | STE | THE |
+      | x         | y         | z         |
+      | key:ref:0 | key:ref:1 | key:ref:2 |
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
@@ -1728,10 +1602,10 @@ Feature: Graql Insert Query
       match $x isa person;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | BEC |
-      | STE |
-      | THE |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
+      | key:ref:2 |
     When graql insert
       """
       match
@@ -1747,10 +1621,10 @@ Feature: Graql Insert Query
       match $x isa person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | BEC |
-      | STE |
-      | THE |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
+      | key:ref:2 |
 
 
   Scenario: match-inserting only existing relations is a no-op
@@ -1765,18 +1639,9 @@ Feature: Graql Insert Query
       $yr (employee: $y, employer: $c) isa employment, has ref 5;
       $zr (employee: $z, employer: $c) isa employment, has ref 6;
       """
-    Given concept identifiers are
-      |      | check | value |
-      | HOM  | key   | ref:0 |
-      | BUR  | key   | ref:1 |
-      | SMI  | key   | ref:2 |
-      | NPP  | key   | ref:3 |
-      | eHOM | key   | ref:4 |
-      | eBUR | key   | ref:5 |
-      | eSMI | key   | ref:6 |
     Given uniquely identify answer concepts
-      | x   | y   | z   | c   | xr   | yr   | zr   |
-      | HOM | BUR | SMI | NPP | eHOM | eBUR | eSMI |
+      | x         | y         | z         | c         | xr        | yr        | zr        |
+      | key:ref:0 | key:ref:1 | key:ref:2 | key:ref:3 | key:ref:4 | key:ref:5 | key:ref:6 |
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
@@ -1785,10 +1650,10 @@ Feature: Graql Insert Query
       match $r (employee: $x, employer: $c) isa employment;
       """
     Given uniquely identify answer concepts
-      | r    | x   | c   |
-      | eHOM | HOM | NPP |
-      | eBUR | BUR | NPP |
-      | eSMI | SMI | NPP |
+      | r         | x         | c         |
+      | key:ref:4 | key:ref:0 | key:ref:3 |
+      | key:ref:5 | key:ref:1 | key:ref:3 |
+      | key:ref:6 | key:ref:2 | key:ref:3 |
     When graql insert
       """
       match
@@ -1804,10 +1669,10 @@ Feature: Graql Insert Query
       match $r (employee: $x, employer: $c) isa employment;
       """
     Then uniquely identify answer concepts
-      | r    | x   | c   |
-      | eHOM | HOM | NPP |
-      | eBUR | BUR | NPP |
-      | eSMI | SMI | NPP |
+      | r         | x         | c         |
+      | key:ref:4 | key:ref:0 | key:ref:3 |
+      | key:ref:5 | key:ref:1 | key:ref:3 |
+      | key:ref:6 | key:ref:2 | key:ref:3 |
 
 
   Scenario: match-inserting only existing attributes is a no-op
@@ -1818,14 +1683,9 @@ Feature: Graql Insert Query
       $y "Misty" isa name;
       $z "Brock" isa name;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | ASH | value | name:Ash   |
-      | MIS | value | name:Misty |
-      | BRO | value | name:Brock |
     Given uniquely identify answer concepts
-      | x   | y   | z   |
-      | ASH | MIS | BRO |
+      | x              | y                | z                |
+      | value:name:Ash | value:name:Misty | value:name:Brock |
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
@@ -1834,10 +1694,10 @@ Feature: Graql Insert Query
       match $x isa name;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | ASH |
-      | MIS |
-      | BRO |
+      | x                |
+      | value:name:Ash   |
+      | value:name:Misty |
+      | value:name:Brock |
     When graql insert
       """
       match
@@ -1853,10 +1713,10 @@ Feature: Graql Insert Query
       match $x isa name;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ASH |
-      | MIS |
-      | BRO |
+      | x                |
+      | value:name:Ash   |
+      | value:name:Misty |
+      | value:name:Brock |
 
 
   Scenario: re-inserting a matched instance does nothing
@@ -1982,16 +1842,13 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When concept identifiers are
-      |     | check | value       |
-      | GAN | value | name:Ganesh |
     When get answers of graql query
       """
       match $x isa name;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | GAN |
+      | x                 |
+      | value:name:Ganesh |
     When graql delete
       """
       match
@@ -2042,19 +1899,14 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When concept identifiers are
-      |     | check | value      |
-      | CHR | key   | ref:0      |
-      | FRE | key   | ref:1      |
-      | TEN | value | score:10.0 |
     When get answers of graql query
       """
       match $x isa person, has score $score;
       """
     Then uniquely identify answer concepts
-      | x   | score |
-      | CHR | TEN   |
-      | FRE | TEN   |
+      | x         | score            |
+      | key:ref:0 | value:score:10.0 |
+      | key:ref:1 | value:score:10.0 |
     When graql delete
       """
       match
@@ -2071,8 +1923,8 @@ Feature: Graql Insert Query
       """
     # The score '10.0' still exists, we never deleted it
     Then uniquely identify answer concepts
-      | x   |
-      | TEN |
+      | x                |
+      | value:score:10.0 |
     When get answers of graql query
       """
       match $x isa person, has score $score;
@@ -2125,17 +1977,13 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When concept identifiers are
-      |     | check | value       |
-      | GAN | value | name:Ganesh |
-      | G   | value | letter:G    |
     When get answers of graql query
       """
       match $x isa name;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | GAN |
+      | x                 |
+      | value:name:Ganesh |
     # At this step we materialise the inferred name 'Ganesh' because the material name-initial relation depends on it.
     When graql insert
       """
@@ -2170,16 +2018,16 @@ Feature: Graql Insert Query
       """
     # We deleted the person called 'Ganesh', but the name still exists because it was materialised on match-insert
     Then uniquely identify answer concepts
-      | x   |
-      | GAN |
+      | x                 |
+      | value:name:Ganesh |
     When get answers of graql query
       """
       match (lettered-name: $x, initial: $y) isa name-initial;
       """
     # And the inserted relation still exists too
     Then uniquely identify answer concepts
-      | x   | y |
-      | GAN | G |
+      | x                 | y              |
+      | value:name:Ganesh | value:letter:G |
 
 
   Scenario: when inserting things connected to an inferred relation, the inferred relation gets materialised

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -72,12 +72,9 @@ Feature: Graql Match Query
       """
       match $x type person;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: 'sub' can be used to match the specified type and all its subtypes, including indirect subtypes
@@ -94,16 +91,11 @@ Feature: Graql Match Query
       """
       match $x sub person;
       """
-    And concept identifiers are
-      |     | check | value        |
-      | PER | label | person       |
-      | WRI | label | writer       |
-      | SCW | label | scifi-writer |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | WRI |
-      | SCW |
+      | x                  |
+      | label:person       |
+      | label:writer       |
+      | label:scifi-writer |
 
 
   Scenario: 'sub' can be used to match the specified type and all its supertypes, including indirect supertypes
@@ -120,16 +112,11 @@ Feature: Graql Match Query
       """
       match writer sub $x;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | WRI | label | writer |
-      | PER | label | person |
-      | ENT | label | entity |
     Then uniquely identify answer concepts
-      | x   |
-      | WRI |
-      | PER |
-      | ENT |
+      | x            |
+      | label:writer |
+      | label:person |
+      | label:entity |
 
 
   Scenario: 'sub' can be used to retrieve all instances of types that are subtypes of a given type
@@ -173,36 +160,22 @@ Feature: Graql Match Query
         $x isa $type;
         $type sub worker;
       """
-    When concept identifiers are
-      |     | check | value                        |
-      | CHA | key   | ref:2                        |
-      | DEB | key   | ref:3                        |
-      | EDM | key   | ref:4                        |
-      | FEL | key   | ref:5                        |
-      | GAR | key   | ref:6                        |
-      | CON | label | construction-worker          |
-      | BRI | label | bricklayer                   |
-      | CRA | label | crane-driver                 |
-      | TEL | label | telecoms-worker              |
-      | MNR | label | mobile-network-researcher    |
-      | TBS | label | telecoms-business-strategist |
-      | WOR | label | worker                       |
     # Alfred and Barbara are not retrieved, as they aren't subtypes of worker
     Then uniquely identify answer concepts
-      | x   | type |
-      | CHA | BRI  |
-      | CHA | CON  |
-      | CHA | WOR  |
-      | DEB | CRA  |
-      | DEB | CON  |
-      | DEB | WOR  |
-      | EDM | MNR  |
-      | EDM | TEL  |
-      | EDM | WOR  |
-      | FEL | TBS  |
-      | FEL | TEL  |
-      | FEL | WOR  |
-      | GAR | WOR  |
+      | x         | type                                |
+      | key:ref:2 | label:bricklayer                    |
+      | key:ref:2 | label:construction-worker           |
+      | key:ref:2 | label:worker                        |
+      | key:ref:3 | label:crane-driver                  |
+      | key:ref:3 | label:construction-worker           |
+      | key:ref:3 | label:worker                        |
+      | key:ref:4 | label:mobile-network-researcher     |
+      | key:ref:4 | label:telecoms-worker               |
+      | key:ref:4 | label:worker                        |
+      | key:ref:5 | label:telecoms-business-strategist  |
+      | key:ref:5 | label:telecoms-worker               |
+      | key:ref:5 | label:worker                        |
+      | key:ref:6 | label:worker                        |
 
 
   Scenario: 'sub!' matches the type's direct subtypes
@@ -221,14 +194,10 @@ Feature: Graql Match Query
       """
       match $x sub! person;
       """
-    And concept identifiers are
-      |     | check | value    |
-      | WRI | label | writer   |
-      | MUS | label | musician |
     Then uniquely identify answer concepts
-      | x   |
-      | WRI |
-      | MUS |
+      | x              |
+      | label:writer   |
+      | label:musician |
 
 
   Scenario: 'sub!' can be used to match a type's direct supertype
@@ -245,12 +214,9 @@ Feature: Graql Match Query
       """
       match writer sub! $x;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
     @ignore
@@ -287,12 +253,9 @@ Feature: Graql Match Query
       """
       match $x owns age;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: 'owns' can match types that can own themselves
@@ -331,14 +294,10 @@ Feature: Graql Match Query
       """
       match $x owns name;
       """
-    And concept identifiers are
-      |     | check | value   |
-      | PER | label | person  |
-      | COM | label | company |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | COM |
+      | x             |
+      | label:person  |
+      | label:company |
 
 
   Scenario: 'owns' does not match types that own only a supertype of the specified attribute type
@@ -356,12 +315,9 @@ Feature: Graql Match Query
       """
       match $x owns club-name;
       """
-    And concept identifiers are
-      |     | check | value |
-      | CLU | label | club  |
     Then uniquely identify answer concepts
-      | x   |
-      | CLU |
+      | x          |
+      | label:club |
 
 
   Scenario: 'owns' can be used to match attribute types that a given type owns
@@ -369,16 +325,11 @@ Feature: Graql Match Query
       """
       match person owns $x;
       """
-    And concept identifiers are
-      |     | check | value |
-      | NAM | label | name  |
-      | AGE | label | age   |
-      | REF | label | ref   |
     Then uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | AGE |
-      | REF |
+      | x          |
+      | label:name |
+      | label:age  |
+      | label:ref  |
 
 
   Scenario: 'owns' can be used to retrieve all instances of types that can own a given attribute type
@@ -409,20 +360,12 @@ Feature: Graql Match Query
         $x isa $type;
         $type owns name;
       """
-    When concept identifiers are
-      |      | check | value      |
-      | PER  | key   | ref:0      |
-      | COM  | key   | ref:1      |
-      | EMP  | key   | ref:3      |
-      | tPER | label | person     |
-      | tCOM | label | company    |
-      | tEMP | label | employment |
     # friendship and ref should not be retrieved, as they can't have a name
     Then uniquely identify answer concepts
-      | x   | type |
-      | PER | tPER |
-      | COM | tCOM |
-      | EMP | tEMP |
+      | x         | type             |
+      | key:ref:0 | label:person     |
+      | key:ref:1 | label:company    |
+      | key:ref:2 | label:employment |
 
 
   Scenario: 'plays' matches types that can play the specified role
@@ -430,12 +373,9 @@ Feature: Graql Match Query
       """
       match $x plays friendship:friend;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: 'plays' does not match types that only play a subrole of the specified role
@@ -452,12 +392,9 @@ Feature: Graql Match Query
       """
       match $x plays friendship:friend;
       """
-    And concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: 'plays' does not match types that only play a super-role of the specified role
@@ -474,12 +411,9 @@ Feature: Graql Match Query
       """
       match $x plays close-friendship:close-friend;
       """
-    And concept identifiers are
-      |     | check | value           |
-      | FRP | label | friendly-person |
     Then uniquely identify answer concepts
-      | x   |
-      | FRP |
+      | x                     |
+      | label:friendly-person |
 
 
   Scenario: 'plays' can be used to match roles that a particular type can play
@@ -487,14 +421,10 @@ Feature: Graql Match Query
       """
       match person plays $x;
       """
-    And concept identifiers are
-      |     | check | value               |
-      | FRI | label | friendship:friend   |
-      | EMP | label | employment:employee |
     Then uniquely identify answer concepts
-      | x   |
-      | FRI |
-      | EMP |
+      | x                         |
+      | label:friendship:friend   |
+      | label:employment:employee |
 
 
   Scenario: 'plays' can be used to retrieve all instances of types that can play a specific role
@@ -526,16 +456,10 @@ Feature: Graql Match Query
         $x isa $type;
         $type plays friendship:friend;
       """
-    When concept identifiers are
-      |      | check | value  |
-      | PER  | key   | ref:0  |
-      | DOG  | key   | ref:2  |
-      | tPER | label | person |
-      | tDOG | label | dog    |
     Then uniquely identify answer concepts
-      | x   | type |
-      | PER | tPER |
-      | DOG | tDOG |
+      | x         | type         |
+      | key:ref:0 | label:person |
+      | key:ref:2 | label:dog    |
 
 
   Scenario: 'owns @key' matches types that own the specified attribute type as a key
@@ -552,12 +476,9 @@ Feature: Graql Match Query
       """
       match $x owns breed @key;
       """
-    And concept identifiers are
-      |     | check | value |
-      | DOG | label | dog   |
     Then uniquely identify answer concepts
-      | x   |
-      | DOG |
+      | x         |
+      | label:dog |
 
 
   Scenario: 'key' can be used to find all attribute types that a given type owns as a key
@@ -565,12 +486,9 @@ Feature: Graql Match Query
       """
       match person owns $x @key;
       """
-    And concept identifiers are
-      |     | check | value |
-      | REF | label | ref   |
     Then uniquely identify answer concepts
-      | x   |
-      | REF |
+      | x         |
+      | label:ref |
 
 
   Scenario: 'owns' without '@key' matches all types that own the specified attribute type, even if they use it as a key
@@ -588,14 +506,10 @@ Feature: Graql Match Query
       """
       match $x owns breed;
       """
-    And concept identifiers are
-      |     | check | value |
-      | DOG | label | dog   |
-      | CAT | label | cat   |
     Then uniquely identify answer concepts
-      | x   |
-      | DOG |
-      | CAT |
+      | x         |
+      | label:dog |
+      | label:cat |
 
 
   Scenario: 'relates' matches relation types where the specified role can be played
@@ -603,12 +517,9 @@ Feature: Graql Match Query
       """
       match $x relates employee;
       """
-    And concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x                |
+      | label:employment |
 
 
   @ignore # TODO cannot currently query for schema with 'as'
@@ -626,12 +537,9 @@ Feature: Graql Match Query
       """
       match $x relates close-friend as friend;
       """
-    And concept identifiers are
-      |     | check | value            |
-      | CLF | label | close-friendship |
     Then uniquely identify answer concepts
-      | x   |
-      | CLF |
+      | x                      |
+      | label:close-friendship |
 
 
   Scenario: 'relates' without 'as' does not match relation types that override the specified roleplayer
@@ -648,12 +556,9 @@ Feature: Graql Match Query
       """
       match $x relates friend;
       """
-    And concept identifiers are
-      |     | check | value      |
-      | FRE | label | friendship |
     Then uniquely identify answer concepts
-      | x   |
-      | FRE |
+      | x                |
+      | label:friendship |
 
 
   Scenario: 'relates' can be used to retrieve all the roles of a relation type
@@ -661,14 +566,10 @@ Feature: Graql Match Query
       """
       match employment relates $x;
       """
-    And concept identifiers are
-      |     | check | value               |
-      | EME | label | employment:employee |
-      | EMR | label | employment:employer |
     Then uniquely identify answer concepts
-      | x   |
-      | EME |
-      | EMR |
+      | x              |
+      | label:employment:employee |
+      | label:employment:employer |
 
 
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
@@ -715,16 +616,11 @@ Feature: Graql Match Query
       """
       match $x isa writer;
       """
-    And concept identifiers are
-      |     | check | value |
-      | WRI | key   | ref:1 |
-      | SCI | key   | ref:2 |
-      | GOO | key   | ref:3 |
     Then uniquely identify answer concepts
-      | x   |
-      | WRI |
-      | SCI |
-      | GOO |
+      | x         |
+      | key:ref:1 |
+      | key:ref:2 |
+      | key:ref:3 |
 
 
   Scenario: 'isa!' only matches things of the specified type, and does not match subtypes
@@ -755,12 +651,9 @@ Feature: Graql Match Query
       """
       match $x isa! writer;
       """
-    And concept identifiers are
-      |     | check | value |
-      | WRI | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x   |
-      | WRI |
+      | x         |
+      | key:ref:1 |
 
 
   Scenario: 'iid' matches the instance with the specified internal iid
@@ -834,12 +727,9 @@ Feature: Graql Match Query
         $x isa person;
         $y isa person;
       """
-    When concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   | y   |
-      | PER | PER |
+      | x         | y         |
+      | key:ref:0 | key:ref:0 |
 
 
   Scenario: an error is thrown when matching that a variable has a specific type, when that type is in fact a role type
@@ -895,21 +785,16 @@ Feature: Graql Match Query
       """
       match $x isa person; $r (employee: $x) isa relation;
       """
-    And concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
-      | REF2 | key   | ref:2 |
     Then uniquely identify answer concepts
-      | x    | r    |
-      | REF0 | REF2 |
+      | x         | r         |
+      | key:ref:0 | key:ref:2 |
     When get answers of graql query
       """
       match $y isa company; $r (employer: $y) isa relation;
       """
     Then uniquely identify answer concepts
-      | y    | r    |
-      | REF1 | REF2 |
+      | y         | r         |
+      | key:ref:1 | key:ref:2 |
 
 
   Scenario: relations are matchable from roleplayers without specifying any roles
@@ -931,13 +816,9 @@ Feature: Graql Match Query
       """
       match $x isa person; $r ($x) isa relation;
       """
-    When concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF2 | key   | ref:2 |
     Then uniquely identify answer concepts
-      | x    | r    |
-      | REF0 | REF2 |
+      | x         | r         |
+      | key:ref:0 | key:ref:2 |
 
 
   Scenario: all combinations of players in a relation can be retrieved
@@ -958,20 +839,14 @@ Feature: Graql Match Query
       """
       match $r ($x, $y) isa employment;
       """
-    And concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
-      | REF2 | key   | ref:2 |
-      | REF3 | key   | ref:3 |
     Then uniquely identify answer concepts
-      | x    | y    | r    |
-      | REF0 | REF1 | REF3 |
-      | REF1 | REF0 | REF3 |
-      | REF0 | REF2 | REF3 |
-      | REF2 | REF0 | REF3 |
-      | REF1 | REF2 | REF3 |
-      | REF2 | REF1 | REF3 |
+      | x         | y         | r         |
+      | key:ref:0 | key:ref:1 | key:ref:3 |
+      | key:ref:1 | key:ref:0 | key:ref:3 |
+      | key:ref:0 | key:ref:2 | key:ref:3 |
+      | key:ref:2 | key:ref:0 | key:ref:3 |
+      | key:ref:1 | key:ref:2 | key:ref:3 |
+      | key:ref:2 | key:ref:1 | key:ref:3 |
 
 
   Scenario: duplicate role players are retrieved singly when queried doubly
@@ -997,13 +872,9 @@ Feature: Graql Match Query
       """
       match $r (player: $x, player: $x) isa relation;
       """
-    And concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x    | r    |
-      | REF0 | REF1 |
+      | x         | r         |
+      | key:ref:0 | key:ref:1 |
 
 
   Scenario: duplicate role players are retrieved singly when queried singly
@@ -1029,13 +900,9 @@ Feature: Graql Match Query
       """
       match $r (player: $x) isa relation;
       """
-    And concept identifiers are
-      |      | check | value |
-      | REF0 | key   | ref:0 |
-      | REF1 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x    | r    |
-      | REF0 | REF1 |
+      | x         | r         |
+      | key:ref:0 | key:ref:1 |
 
 
   Scenario: relations between distinct concepts are not retrieved when matching concepts that relate to themselves
@@ -1098,14 +965,9 @@ Feature: Graql Match Query
         (sender: $a, recipient: $b) isa gift-delivery;
         (sender: $b, recipient: $c) isa gift-delivery;
       """
-    When concept identifiers are
-      |     | check | value |
-      | SOR | key   | ref:0 |
-      | MAR | key   | ref:1 |
-      | PAT | key   | ref:2 |
     Then uniquely identify answer concepts
-      | a   | b   | c   |
-      | SOR | MAR | PAT |
+      | a         | b         | c         |
+      | key:ref:0 | key:ref:1 | key:ref:2 |
     When get answers of graql query
       """
       match
@@ -1141,35 +1003,29 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Given concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
-      | EMP | key   | ref:1 |
-      | FRI | key   | ref:2 |
-      | RES | key   | ref:3 |
     Given get answers of graql query
       """
       match $r isa relation;
       """
     Given uniquely identify answer concepts
-      | r   |
-      | EMP |
-      | FRI |
-      | RES |
+      | r         |
+      | key:ref:1 |
+      | key:ref:2 |
+      | key:ref:3 |
     When get answers of graql query
       """
       match ($x) isa relation;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
     When get answers of graql query
       """
       match ($x);
       """
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: an error is thrown when matching an entity type as if it were a role type
@@ -1247,12 +1103,9 @@ Feature: Graql Match Query
       """
       match $a <value>;
       """
-    And concept identifiers are
-      |     | check | value |
-      | ATT | key   | ref:0 |
     Then uniquely identify answer concepts
-      | a   |
-      | ATT |
+      | a         |
+      | key:ref:0 |
 
     Examples:
       | attr        | type     | value      |
@@ -1304,14 +1157,10 @@ Feature: Graql Match Query
       """
       match $x contains "Fun";
       """
-    And concept identifiers are
-      |     | check | value                            |
-      | FOU | value | name:Four Weddings and a Funeral |
-      | FUN | value | name:Fun Facts about Space       |
     Then uniquely identify answer concepts
-      | x   |
-      | FOU |
-      | FUN |
+      | x                                      |
+      | value:name:Four Weddings and a Funeral |
+      | value:name:Fun Facts about Space       |
 
 
   Scenario: 'contains' performs a case-insensitive match
@@ -1332,14 +1181,10 @@ Feature: Graql Match Query
       """
       match $x contains "Bean";
       """
-    And concept identifiers are
-      |     | check | value                         |
-      | PIR | value | name:Pirates of the Caribbean |
-      | MRB | value | name:Mr. Bean                 |
     Then uniquely identify answer concepts
-      | x   |
-      | PIR |
-      | MRB |
+      | x                                   |
+      | value:name:Pirates of the Caribbean |
+      | value:name:Mr. Bean                 |
 
 
   Scenario: 'like' matches strings that match the specified regex
@@ -1360,14 +1205,10 @@ Feature: Graql Match Query
       """
       match $x like "^[0-9]+$";
       """
-    And concept identifiers are
-      |     | check | value       |
-      | ONE | value | name:123456 |
-      | NIN | value | name:9      |
     Then uniquely identify answer concepts
-      | x   |
-      | ONE |
-      | NIN |
+      | x                 |
+      | value:name:123456 |
+      | value:name:9      |
 
 
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
@@ -1408,14 +1249,10 @@ Feature: Graql Match Query
       """
       match $x has name $y; get $x;
       """
-    And concept identifiers are
-      |     | check | value |
-      | LEI | key   | ref:0 |
-      | GRA | key   | ref:2 |
     Then uniquely identify answer concepts
-      | x   |
-      | LEI |
-      | GRA |
+      | x         |
+      | key:ref:0 |
+      | key:ref:2 |
 
 
   Scenario: using the 'attribute' meta label, 'has' can match things that own any attribute with a specified value
@@ -1444,14 +1281,10 @@ Feature: Graql Match Query
       """
       match $x has attribute 9;
       """
-    And concept identifiers are
-      |     | check | value |
-      | AG9 | key   | ref:0 |
-      | SS9 | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x   |
-      | AG9 |
-      | SS9 |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
 
 
   Scenario: when an attribute instance is fully specified, 'has' matches its owners
@@ -1484,16 +1317,11 @@ Feature: Graql Match Query
       """
       match $x has age 21;
       """
-    And concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
-      | FRI | key   | ref:1 |
-      | GRA | key   | ref:2 |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | FRI |
-      | GRA |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
+      | key:ref:2 |
 
 
   Scenario: 'has' matches an attribute's owner even if it owns more attributes of the same type
@@ -1520,12 +1348,9 @@ Feature: Graql Match Query
       """
       match $x has lucky-number 20;
       """
-    And concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: 'has' can match instances that have themselves
@@ -1637,12 +1462,9 @@ Feature: Graql Match Query
       """
       match $x has age = 16;
       """
-    And concept identifiers are
-      |     | check | value |
-      | SUS | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | SUS |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: 'has $attr > $x' matches owners of any instance '$y' of '$attr' where '$y > $x'
@@ -1663,12 +1485,9 @@ Feature: Graql Match Query
       """
       match $x has age > 18;
       """
-    And concept identifiers are
-      |     | check | value |
-      | DON | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x   |
-      | DON |
+      | x         |
+      | key:ref:1 |
 
 
   Scenario: 'has $attr < $x' matches owners of any instance '$y' of '$attr' where '$y < $x'
@@ -1689,12 +1508,9 @@ Feature: Graql Match Query
       """
       match $x has age < 18;
       """
-    And concept identifiers are
-      |     | check | value |
-      | SUS | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | SUS |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: 'has $attr != $x' matches owners of any instance '$y' of '$attr' where '$y != $x'
@@ -1715,14 +1531,10 @@ Feature: Graql Match Query
       """
       match $x has age != 18;
       """
-    And concept identifiers are
-      |     | check | value |
-      | DON | key   | ref:1 |
-      | SUS | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | DON |
-      | SUS |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
 
 
   Scenario: value comparisons can be performed between a 'double' and a 'long'
@@ -1814,12 +1626,9 @@ Feature: Graql Match Query
       """
       match $x has lucky-number > 25;
       """
-    And concept identifiers are
-      |     | check | value |
-      | PER | key   | ref:0 |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: an attribute variable used in both '=' and '>=' predicates is correctly resolved
@@ -1844,14 +1653,10 @@ Feature: Graql Match Query
         $z isa age;
       get $x;
       """
-    And concept identifiers are
-      |     | check | value |
-      | DON | key   | ref:1 |
-      | RAL | key   | ref:2 |
     Then uniquely identify answer concepts
-      | x   |
-      | DON |
-      | RAL |
+      | x         |
+      | key:ref:1 |
+      | key:ref:2 |
 
 
   Scenario: when the answers of a value comparison include both a 'double' and a 'long', both answers are returned
@@ -1882,16 +1687,10 @@ Feature: Graql Match Query
         $x isa attribute;
         $x > 20;
       """
-    And concept identifiers are
-      |      | check | value       |
-      | A24  | value | age:24      |
-      | A19  | value | age:19      |
-      | L209 | value | length:20.9 |
-      | L199 | value | length:19.9 |
     Then uniquely identify answer concepts
-      | x    |
-      | A24  |
-      | L209 |
+      | x                 |
+      | value:age:24      |
+      | value:length:20.9 |
 
 
   Scenario: when one entity exists, and we match two variables with concept inequality, an empty answer is returned
@@ -1943,14 +1742,10 @@ Feature: Graql Match Query
       """
       match {$x isa person;} or {$x isa company;};
       """
-    And concept identifiers are
-      |     | check | value |
-      | JEF | key   | ref:0 |
-      | AMA | key   | ref:1 |
     Then uniquely identify answer concepts
-      | x   |
-      | JEF |
-      | AMA |
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
 
 
   ##################

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -271,12 +271,9 @@ Feature: Graql Match Query
       """
       match $x owns $x;
       """
-    And concept identifiers are
-      |      | check | value  |
-      | UNIT | label | unit   |
     Then uniquely identify answer concepts
-      | x    |
-      | UNIT |
+      | x          |
+      | label:unit |
 
 
   Scenario: 'owns' does not match types that own only a subtype of the specified attribute type
@@ -1376,12 +1373,9 @@ Feature: Graql Match Query
       """
       match $x has $x;
       """
-    And concept identifiers are
-      |       | check | value  |
-      | METER | key   | ref:0  |
     Then uniquely identify answer concepts
-      | x     |
-      | METER |
+      | x         |
+      | key:ref:0 |
 
 
   Scenario: an error is thrown when matching by attribute ownership, when the owned thing is actually an entity

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -362,7 +362,7 @@ Feature: Graql Match Query
       | x         | type             |
       | key:ref:0 | label:person     |
       | key:ref:1 | label:company    |
-      | key:ref:2 | label:employment |
+      | key:ref:3 | label:employment |
 
 
   Scenario: 'plays' matches types that can play the specified role

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -19,8 +19,7 @@ Feature: Graql Rule Validation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection open sessions for databases:
-      | test_rule_validation |
+    Given connection open session for databases: test_rule_validation
     Given transaction is initialised
     Given graql define
       """
@@ -57,14 +56,10 @@ Feature: Graql Rule Validation
       """
       match $x sub rule;
       """
-    Then concept identifiers are
-      |     | check | value                   |
-      | BOB | label | robert-has-nickname-bob |
-      | RUL | label | rule                    |
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
-      | RUL |
+      | x                             |
+      | label:robert-has-nickname-bob |
+      | label:rule                    |
 
 
   # Keys are validated at commit time, so integrity will not be harmed by writing one in a rule.
@@ -83,14 +78,10 @@ Feature: Graql Rule Validation
       """
       match $x sub rule;
       """
-    Then concept identifiers are
-      |     | check | value             |
-      | JSE | label | john-smiths-email |
-      | RUL | label | rule              |
     Then uniquely identify answer concepts
-      | x   |
-      | JSE |
-      | RUL |
+      | x                       |
+      | label:john-smiths-email |
+      | label:rule              |
 
 
   Scenario: when a rule has no 'when' clause, an error is thrown
@@ -170,14 +161,10 @@ Feature: Graql Rule Validation
       """
       match $x sub rule;
       """
-    Then concept identifiers are
-      |     | check | value           |
-      | ONL | label | only-child-rule |
-      | RUL | label | rule            |
     Then uniquely identify answer concepts
-      | x   |
-      | ONL |
-      | RUL |
+      | x                     |
+      | label:only-child-rule |
+      | label:rule            |
 
 
   Scenario: when a rule has a negation block whose pattern variables are all unbound outside it, an error is thrown
@@ -301,14 +288,10 @@ Feature: Graql Rule Validation
       """
       match $x sub rule;
       """
-    Then concept identifiers are
-      |     | check | value                             |
-      | BOB | label | two-roberts-are-both-named-robert |
-      | RUL | label | rule                              |
     Then uniquely identify answer concepts
-      | x   |
-      | BOB |
-      | RUL |
+      | x                                       |
+      | label:two-roberts-are-both-named-robert |
+      | label:rule                              |
 
 
   Scenario: when a rule contains a disjunction, an error is thrown

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -48,16 +48,11 @@ Feature: Graql Undefine Query
       """
       match $x sub entity;
       """
-    Given concept identifiers are
-      |     | check | value         |
-      | ABS | label | abstract-type |
-      | PER | label | person        |
-      | ENT | label | entity        |
     Given uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | PER |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:person        |
+      | label:entity        |
     When graql undefine
       """
       undefine person sub entity;
@@ -70,9 +65,9 @@ Feature: Graql Undefine Query
       match $x sub entity;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:entity        |
 
 
   Scenario: when undefining 'sub' on an entity type, specifying a type that isn't really its supertype, nothing happens
@@ -87,12 +82,9 @@ Feature: Graql Undefine Query
       """
       match $x type person;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: a sub-entity type can be removed using 'sub' with its direct supertype, and its parent is preserved
@@ -107,14 +99,10 @@ Feature: Graql Undefine Query
       """
       match $x sub person;
       """
-    Given concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHI | label | child  |
     Given uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHI |
+      | x            |
+      | label:person |
+      | label:child  |
     When graql undefine
       """
       undefine child sub person;
@@ -127,8 +115,8 @@ Feature: Graql Undefine Query
       match $x sub person;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: if 'entity' is not the direct supertype of an entity, undefining 'sub entity' on it does nothing
@@ -150,12 +138,9 @@ Feature: Graql Undefine Query
       """
       match $x type child;
       """
-    When concept identifiers are
-      |     | check | value |
-      | CHI | label | child |
     Then uniquely identify answer concepts
-      | x   |
-      | CHI |
+      | x           |
+      | label:child |
 
 
   Scenario: undefining a supertype throws an error if subtypes exist
@@ -244,16 +229,11 @@ Feature: Graql Undefine Query
       """
       match $x sub entity;
       """
-    Given concept identifiers are
-      |     | check | value         |
-      | ABS | label | abstract-type |
-      | PER | label | person        |
-      | ENT | label | entity        |
     Given uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | PER |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:person        |
+      | label:entity        |
     Given transaction commits
     Given the integrity is validated
     Given connection close all sessions
@@ -300,9 +280,9 @@ Feature: Graql Undefine Query
       match $x sub entity;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:entity        |
 
 
   ##################
@@ -314,14 +294,10 @@ Feature: Graql Undefine Query
       """
       match $x sub relation;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
-      | REL | label | relation   |
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | REL |
+      | x                |
+      | label:employment |
+      | label:relation   |
     When graql undefine
       """
       undefine employment sub relation;
@@ -334,8 +310,8 @@ Feature: Graql Undefine Query
       match $x sub relation;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | REL |
+      | x              |
+      | label:relation |
 
 
   Scenario: removing playable roles from a super relation type also removes them from its subtypes
@@ -353,12 +329,9 @@ Feature: Graql Undefine Query
       """
       match contract-employment plays $x;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | EWT | label | employment |
     Given uniquely identify answer concepts
-      | x   |
-      | EWT |
+      | x                |
+      | label:employment |
     When graql undefine
       """
       undefine employment plays employment-terms:employment;
@@ -388,14 +361,10 @@ Feature: Graql Undefine Query
       """
       match $x owns start-date;
       """
-    Given concept identifiers are
-      |     | check | value               |
-      | EMP | label | employment          |
-      | CEM | label | contract-employment |
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | CEM |
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
     When graql undefine
       """
       undefine employment owns start-date;
@@ -425,14 +394,10 @@ Feature: Graql Undefine Query
       """
       match $x owns employment-reference @key;
       """
-    Given concept identifiers are
-      |     | check | value               |
-      | EMP | label | employment          |
-      | CEM | label | contract-employment |
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | CEM |
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
     When graql undefine
       """
       undefine employment owns employment-reference;
@@ -478,14 +443,10 @@ Feature: Graql Undefine Query
       """
       match $x sub relation;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | EMP | label | employment |
-      | REL | label | relation   |
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | REL |
+      | x                |
+      | label:employment |
+      | label:relation   |
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -532,8 +493,8 @@ Feature: Graql Undefine Query
       match $x sub relation;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | REL |
+      | x              |
+      | label:relation |
 
 
   Scenario: undefining a relation type automatically detaches any possible roleplayers
@@ -543,13 +504,9 @@ Feature: Graql Undefine Query
         $x type person;
         $x plays $y;
       """
-    Given concept identifiers are
-      |     | check | value               |
-      | PER | label | person              |
-      | EME | label | employment:employee |
     Given uniquely identify answer concepts
-      | x   | y   |
-      | PER | EME |
+      | x            | y                         |
+      | label:person | label:employment:employee |
     When graql undefine
       """
       undefine employment sub relation;
@@ -575,14 +532,10 @@ Feature: Graql Undefine Query
       """
       match employment relates $x;
       """
-    Given concept identifiers are
-      |     | check | value    |
-      | EME | label | employee |
-      | EMR | label | employer |
     Given uniquely identify answer concepts
-      | x   |
-      | EME |
-      | EMR |
+      | x              |
+      | label:employee |
+      | label:employer |
     When graql undefine
       """
       undefine employment relates employee;
@@ -595,8 +548,8 @@ Feature: Graql Undefine Query
       match employment relates $x;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | EMR |
+      | x              |
+      | label:employer |
 
 
   Scenario: undefining all players of a role produces a valid schema
@@ -683,13 +636,9 @@ Feature: Graql Undefine Query
         $x type person;
         $x plays $y;
       """
-    Given concept identifiers are
-      |     | check | value               |
-      | PER | label | person              |
-      | EME | label | employment:employee |
     Given uniquely identify answer concepts
-      | x   | y   |
-      | PER | EME |
+      | x            | y                         |
+      | label:person | label:employment:employee |
     When graql undefine
       """
       undefine employment relates employee;
@@ -762,12 +711,9 @@ Feature: Graql Undefine Query
       """
       match employment relates $x;
       """
-    When concept identifiers are
-      |     | check | value    |
-      | EME | label | employee |
     Then uniquely identify answer concepts
-      | x   |
-      | EME |
+      | x              |
+      | label:employee |
 
 
   Scenario: removing a role from a super relation type also removes it from its subtypes
@@ -789,13 +735,9 @@ Feature: Graql Undefine Query
       """
       match $x type part-time; $x relates $role;
       """
-    Then concept identifiers are
-      |           | check | value     |
-      | EMPLOYEE  | label | employee  |
-      | PART_TIME | label | part-time |
     Then uniquely identify answer concepts
-      | x         | role     |
-      | PART_TIME | EMPLOYEE |
+      | x               | role           |
+      | label:part-time | label:employee |
 
   # TODO
   Scenario: removing a role from a super relation type also removes roles that override it in its subtypes (?)
@@ -862,12 +804,9 @@ Feature: Graql Undefine Query
       """
       match person plays $x;
       """
-    Given concept identifiers are
-      |     | check | value    |
-      | EMP | label | employee |
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x              |
+      | label:employee |
     When graql undefine
       """
       undefine person plays employment:employer;
@@ -880,8 +819,8 @@ Feature: Graql Undefine Query
       match person plays $x;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | EMP |
+      | x              |
+      | label:employee |
 
 
   Scenario: removing a playable role throws an error if it is played by existing instances
@@ -992,12 +931,9 @@ Feature: Graql Undefine Query
       """
       match first-name plays $x;
       """
-    Given concept identifiers are
-      |     | check | value        |
-      | MNA | label | manager-name |
     Given uniquely identify answer concepts
-      | x   |
-      | MNA |
+      | x                  |
+      | label:manager-name |
     When graql undefine
       """
       undefine name plays employment:manager-name;
@@ -1028,14 +964,10 @@ Feature: Graql Undefine Query
       """
       match $x owns locale;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | NAM | label | name       |
-      | FNA | label | first-name |
     Given uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | FNA |
+      | x                |
+      | label:name       |
+      | label:first-name |
     When graql undefine
       """
       undefine name owns locale;
@@ -1066,14 +998,10 @@ Feature: Graql Undefine Query
       """
       match $x owns name-id @key;
       """
-    Given concept identifiers are
-      |     | check | value      |
-      | NAM | label | name       |
-      | FNA | label | first-name |
     Given uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | FNA |
+      | x                |
+      | label:name       |
+      | label:first-name |
     When graql undefine
       """
       undefine name owns name-id;
@@ -1125,16 +1053,11 @@ Feature: Graql Undefine Query
       """
       match $x sub attribute;
       """
-    Given concept identifiers are
-      |     | check | value     |
-      | NAM | label | name      |
-      | EMA | label | email     |
-      | ATT | label | attribute |
     Given uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:name      |
+      | label:email     |
+      | label:attribute |
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1179,9 +1102,9 @@ Feature: Graql Undefine Query
       match $x sub attribute;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:email     |
+      | label:attribute |
 
 
   ########################
@@ -1195,12 +1118,9 @@ Feature: Graql Undefine Query
         $x owns name;
         $x type person;
       """
-    Given concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Given uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
     When graql undefine
       """
       undefine person owns name;
@@ -1246,14 +1166,10 @@ Feature: Graql Undefine Query
       """
       match $x owns name;
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
-      | CHI | label | child  |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
-      | CHI |
+      | x            |
+      | label:person |
+      | label:child  |
 
 
   Scenario: undefining a key ownership removes it
@@ -1292,12 +1208,9 @@ Feature: Graql Undefine Query
       """
       match $x owns name;
       """
-    Given concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Given uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
     Given transaction commits
     Given the integrity is validated
     Given connection close all sessions
@@ -1389,14 +1302,10 @@ Feature: Graql Undefine Query
       """
       match $x sub rule;
       """
-    Then concept identifiers are
-      |        | check | value  |
-      | RULE   | label | rule   |
-      | A_RULE | label | a-rule |
     When uniquely identify answer concepts
-      | x      |
-      | RULE   |
-      | A_RULE |
+      | x            |
+      | label:rule   |
+      | label:a-rule |
     When graql undefine
       """
       undefine rule a-rule;
@@ -1439,12 +1348,9 @@ Feature: Graql Undefine Query
         $x has name $n;
       get $n;
       """
-    Given concept identifiers are
-      |     | check | value       |
-      | SAM | value | name:Samuel |
     Given uniquely identify answer concepts
-      | n   |
-      | SAM |
+      | n                 |
+      | value:name:Samuel |
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1495,12 +1401,9 @@ Feature: Graql Undefine Query
         $x has name $n;
       get $n;
       """
-    Given concept identifiers are
-      |     | check | value       |
-      | SAM | value | name:Samuel |
     Given uniquely identify answer concepts
-      | n   |
-      | SAM |
+      | n                 |
+      | value:name:Samuel |
     When graql undefine
       """
       undefine rule samuel-email-rule;
@@ -1513,8 +1416,8 @@ Feature: Graql Undefine Query
       get $n;
       """
     Then uniquely identify answer concepts
-      | n   |
-      | SAM |
+      | n                 |
+      | value:name:Samuel |
 
 
   ############
@@ -1555,12 +1458,9 @@ Feature: Graql Undefine Query
         $x type abstract-type;
         not { $x abstract; };
       """
-    Then concept identifiers are
-      |     | check | value         |
-      | ABS | label | abstract-type |
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
+      | x                   |
+      | label:abstract-type |
     When graql insert
       """
       insert $x isa abstract-type;
@@ -1589,12 +1489,9 @@ Feature: Graql Undefine Query
         $x type person;
         not { $x abstract; };
       """
-    When concept identifiers are
-      |     | check | value  |
-      | PER | label | person |
     Then uniquely identify answer concepts
-      | x   |
-      | PER |
+      | x            |
+      | label:person |
 
 
   Scenario: an abstract type can be changed into a concrete type even if has an abstract child type
@@ -1618,12 +1515,9 @@ Feature: Graql Undefine Query
         $x type abstract-type;
         not { $x abstract; };
       """
-    When concept identifiers are
-      |     | check | value         |
-      | ABS | label | abstract-type |
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
+      | x                   |
+      | label:abstract-type |
 
 
   Scenario: undefining abstract on an attribute type is allowed, even if that attribute type has an owner
@@ -1660,32 +1554,24 @@ Feature: Graql Undefine Query
   ###################
 
   Scenario: a type and an attribute type that it owns can be removed simultaneously
-    Given concept identifiers are
-      |     | check | value         |
-      | PER | label | person        |
-      | ABS | label | abstract-type |
-      | ENT | label | entity        |
-      | NAM | label | name          |
-      | EMA | label | email         |
-      | ATT | label | attribute     |
     Given get answers of graql query
       """
       match $x sub entity;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | PER |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:person        |
+      | label:abstract-type |
+      | label:entity        |
     Given get answers of graql query
       """
       match $x sub attribute;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:name      |
+      | label:email     |
+      | label:attribute |
     When graql undefine
       """
       undefine
@@ -1700,68 +1586,55 @@ Feature: Graql Undefine Query
       match $x sub entity;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:entity        |
     When get answers of graql query
       """
       match $x sub attribute;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:email     |
+      | label:attribute |
 
 
   Scenario: a type, a relation type that it plays in and an attribute type that it owns can be removed simultaneously
-    Given concept identifiers are
-      |     | check | value         |
-      | PER | label | person        |
-      | ABS | label | abstract-type |
-      | ENT | label | entity        |
-      | EMP | label | employment    |
-      | REL | label | relation      |
-      | EME | label | employee      |
-      | EMR | label | employer      |
-      | ROL | label | role          |
-      | NAM | label | name          |
-      | EMA | label | email         |
-      | ATT | label | attribute     |
     Given get answers of graql query
       """
       match $x sub entity;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | PER |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:person        |
+      | label:abstract-type |
+      | label:entity        |
     Given get answers of graql query
       """
       match $x sub relation;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | EMP |
-      | REL |
+      | x                |
+      | label:employment |
+      | label:relation   |
     Given get answers of graql query
       """
       match $x sub attribute;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | NAM |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:name      |
+      | label:email     |
+      | label:attribute |
     Given get answers of graql query
       """
       match $x sub role;
       """
     Given uniquely identify answer concepts
-      | x   |
-      | EME |
-      | EMR |
-      | ROL |
+      | x              |
+      | label:employee |
+      | label:employer |
+      | label:role     |
     When graql undefine
       """
       undefine
@@ -1777,28 +1650,28 @@ Feature: Graql Undefine Query
       match $x sub entity;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ABS |
-      | ENT |
+      | x                   |
+      | label:abstract-type |
+      | label:entity        |
     When get answers of graql query
       """
       match $x sub relation;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | REL |
+      | x              |
+      | label:relation |
     When get answers of graql query
       """
       match $x sub attribute;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | EMA |
-      | ATT |
+      | x               |
+      | label:email     |
+      | label:attribute |
     When get answers of graql query
       """
       match $x sub role;
       """
     Then uniquely identify answer concepts
-      | x   |
-      | ROL |
+      | x          |
+      | label:role |


### PR DESCRIPTION
## What is the goal of this PR?

We updated our behavioural tests to have more atomicity in the test steps involving answer concepts. Additionally, assorted other changes have been made to streamline the process of creating scenarios, and a number of additional testing scenarios have been introduced.

## What are the changes implemented in this PR?

Scenarios have been added for testing schema writes in data sessions and vice versa.
A large quantity of singeton data tables have been reformatted to give a single string instead. 
All instances of `Uniquely identify answer concepts` and related steps (full list below) have been restructured to give all required information as part of the single step, instead of having to route via `When concept identifiers are`.
Where `When concept identifiers are` not matched to a `answers contain explanation tree` step, the `When concept identifiers are` step has been removed.
`Group identifiers are` steps have similarly been culled.
The malfunctioning scenario for testing attempted writes in a read transaction has been altered to fail in the correct manner.

Full list of modified steps:
`uniquely identify answer concepts as`
`order of value concepts is`
`answer groups are` (most affected- looks for owner instead of an identified group now)
`group aggregate values are`

