### PR TITLE
Add Thing as retrieved supertype

### DIFF
--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -179,20 +179,24 @@ Feature: Concept Attribute Type
     Then attribute(real-name) get supertype: name
     Then attribute(username) get supertype: name
     Then attribute(first-name) get supertypes contain:
+      | thing      |
       | attribute  |
       | first-name |
       | real-name  |
       | name       |
     Then attribute(last-name) get supertypes contain:
+      | thing     |
       | attribute |
       | last-name |
       | real-name |
       | name      |
     Then attribute(real-name) get supertypes contain:
+      | thing     |
       | attribute |
       | real-name |
       | name      |
     Then attribute(username) get supertypes contain:
+      | thing     |
       | attribute |
       | username  |
       | name      |
@@ -226,20 +230,24 @@ Feature: Concept Attribute Type
     Then attribute(real-name) get supertype: name
     Then attribute(username) get supertype: name
     Then attribute(first-name) get supertypes contain:
+      | thing      |
       | attribute  |
       | first-name |
       | real-name  |
       | name       |
     Then attribute(last-name) get supertypes contain:
+      | thing     |
       | attribute |
       | last-name |
       | real-name |
       | name      |
     Then attribute(real-name) get supertypes contain:
+      | thing     |
       | attribute |
       | real-name |
       | name      |
     Then attribute(username) get supertypes contain:
+      | thing     |
       | attribute |
       | username  |
       | name      |

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -132,20 +132,24 @@ Feature: Concept Entity Type
     Then entity(person) get supertype: animal
     Then entity(cat) get supertype: animal
     Then entity(man) get supertypes contain:
+      | thing  |
       | entity |
       | man    |
       | person |
       | animal |
     Then entity(woman) get supertypes contain:
+      | thing  |
       | entity |
       | woman  |
       | person |
       | animal |
     Then entity(person) get supertypes contain:
+      | thing  |
       | entity |
       | person |
       | animal |
     Then entity(cat) get supertypes contain:
+      | thing  |
       | entity |
       | cat    |
       | animal |
@@ -179,20 +183,24 @@ Feature: Concept Entity Type
     Then entity(person) get supertype: animal
     Then entity(cat) get supertype: animal
     Then entity(man) get supertypes contain:
+      | thing  |
       | entity |
       | man    |
       | person |
       | animal |
     Then entity(woman) get supertypes contain:
+      | thing  |
       | entity |
       | woman  |
       | person |
       | animal |
     Then entity(person) get supertypes contain:
+      | thing  |
       | entity |
       | person |
       | animal |
     Then entity(cat) get supertypes contain:
+      | thing  |
       | entity |
       | cat    |
       | animal |

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -233,6 +233,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(fathership) get role(father) get supertype: parentship:parent
     Then relation(fathership) get role(child) get supertype: relation:role
     Then relation(fathership) get supertypes contain:
+      | thing      |
       | relation   |
       | parentship |
       | fathership |
@@ -266,6 +267,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(fathership) get role(father) get supertype: parentship:parent
     Then relation(fathership) get role(child) get supertype: relation:role
     Then relation(fathership) get supertypes contain:
+      | thing      |
       | relation   |
       | parentship |
       | fathership |
@@ -300,6 +302,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(father-son) get role(father) get supertype: parentship:parent
     Then relation(father-son) get role(son) get supertype: parentship:child
     Then relation(father-son) get supertypes contain:
+      | thing      |
       | relation   |
       | parentship |
       | fathership |
@@ -341,6 +344,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(father-son) get role(father) get supertype: parentship:parent
     Then relation(father-son) get role(son) get supertype: parentship:child
     Then relation(father-son) get supertypes contain:
+      | thing      |
       | relation   |
       | parentship |
       | fathership |
@@ -357,6 +361,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(fathership) get role(father) get supertype: parentship:parent
     Then relation(fathership) get role(child) get supertype: relation:role
     Then relation(fathership) get supertypes contain:
+      | thing      |
       | relation   |
       | parentship |
       | fathership |

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -117,6 +117,7 @@ Feature: Graql Match Query
       | label:writer |
       | label:person |
       | label:entity |
+      | label:thing  |
 
 
   Scenario: 'sub' can be used to retrieve all instances of types that are subtypes of a given type
@@ -219,8 +220,8 @@ Feature: Graql Match Query
       | label:person |
 
 
-    @ignore
-    # TODO this does not work on types anymore - types cannot be specified by IID
+  @ignore
+  # TODO this does not work on types anymore - types cannot be specified by IID
   Scenario: subtype hierarchy satisfies transitive sub assertions
     Given graql define
       """
@@ -737,7 +738,7 @@ Feature: Graql Match Query
     Then the integrity is validated
 
 
-    @ignore # TODO we can't query for rule anymore
+  @ignore # TODO we can't query for rule anymore
   Scenario: an error is thrown when matching that a variable has a specific type, when that type is in fact a rule
     Given graql define
       """
@@ -1779,10 +1780,10 @@ Feature: Graql Match Query
       """
       match $x isa $type;
       """
-    # 2 entities x 2 types {person,entity}
-    # 1 relation x 2 types {friendship,relation}
-    # 5 attributes x 2 types {ref/name,attribute}
-    Then answer size is: 16
+    # 2 entities x 3 types {person,entity,thing}
+    # 1 relation x 3 types {friendship,relation,thing}
+    # 5 attributes x 3 types {ref/name,attribute,thing}
+    Then answer size is: 24
 
 
   Scenario: all relations and their types can be retrieved
@@ -1814,8 +1815,8 @@ Feature: Graql Match Query
       """
       match ($x, $y) isa $type;
       """
-    # 2 permutations x 2 types {friendship,relation}
-    Then answer size is: 4
+    # 2 permutations x 3 types {friendship,relation,thing}
+    Then answer size is: 6
 
 
   #######################


### PR DESCRIPTION
## What is the goal of this PR?
Re-add `thing` as a retrieved type, to be consistent with our descriptive language and mental models of Graql. The alternative is to remove the keyword `thing` as being queryable at all.

## What are the changes implemented in this PR?
* Update test to re-include `thing` as a returned type