### PR TITLE
Connection scenario corrections

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -140,12 +140,11 @@ Feature: Connection Database
     When session opens transaction of type: write
     When connection delete database: grakn
     Then connection does not have database: grakn
-    Then for each transaction, define query; throws exception containing "transaction has been closed"
+    Then graql define; throws exception containing "transaction has been closed"
       """
       define person sub entity;
       """
 
   Scenario: delete a nonexistent database throws an error
     When connection delete database; throws exception: grakn
-
-    #TODO: CONTINUE REMOVING SINGLETONS
+    

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -163,7 +163,8 @@ Feature: Connection Session
       """
       define person sub entity;
       """
-    Then graql insert; throws exception containing "session type does not allow"
+    Then graql insert
       """
       insert $x isa person;
       """
+    Then transaction commits; throws exception containing "session type does not allow"


### PR DESCRIPTION
## What is the goal of this PR?

We updated the scenario "write data in schema session" to properly reflect intended behaviour- it should throw when committed, not on the write itself. 

## What are the changes implemented in this PR?

Wording of the graql define step in database.feature has been corrected to the new format
An additional commit step has been added to the write data in schema session scenario, with the throw moved to that step.
