### PR TITLE
Make steps that override 'plays' refer to the overridden type by scoped label

### DIFF
--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -1099,7 +1099,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:child
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     Then entity(man) get playing roles contain:
       | fathership:father |
       | parentship:child  |
@@ -1117,7 +1117,7 @@ Feature: Concept Entity Type
     When relation(mothership) set relates role: mother as parent
     When put entity type: woman
     When entity(woman) set supertype: person
-    When entity(woman) set plays role: mothership:mother as parent
+    When entity(woman) set plays role: mothership:mother as parentship:parent
     Then entity(woman) get playing roles contain:
       | mothership:mother |
       | parentship:child  |
@@ -1158,10 +1158,10 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     When transaction commits
     When session opens transaction of type: write
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
 
   Scenario: Entity types cannot redeclare inherited/overridden playing role types
     When put relation type: parentship
@@ -1173,7 +1173,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     When put entity type: boy
     When entity(boy) set supertype: man
     When transaction commits
@@ -1190,7 +1190,7 @@ Feature: Concept Entity Type
     When relation(fathership) set relates role: father as parent
     When put entity type: person
     When entity(person) set plays role: parentship:parent
-    Then entity(person) set plays role: fathership:father as parent; throws exception
+    Then entity(person) set plays role: fathership:father as parentship:parent; throws exception
 
   Scenario: Entity types cannot override inherited playing role types other than with their subtypes
     When put relation type: parentship
@@ -1203,4 +1203,4 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:child
     When put entity type: man
     When entity(man) set supertype: person
-    Then entity(man) set plays role: fathership:father as parent; throws exception
+    Then entity(man) set plays role: fathership:father as parentship:parent; throws exception

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -1099,7 +1099,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:child
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parentship:parent
+    When entity(man) set plays role: fathership:father as parent
     Then entity(man) get playing roles contain:
       | fathership:father |
       | parentship:child  |
@@ -1117,7 +1117,7 @@ Feature: Concept Entity Type
     When relation(mothership) set relates role: mother as parent
     When put entity type: woman
     When entity(woman) set supertype: person
-    When entity(woman) set plays role: mothership:mother as parentship:parent
+    When entity(woman) set plays role: mothership:mother as parent
     Then entity(woman) get playing roles contain:
       | mothership:mother |
       | parentship:child  |
@@ -1158,10 +1158,10 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parentship:parent
+    When entity(man) set plays role: fathership:father as parent
     When transaction commits
     When session opens transaction of type: write
-    When entity(man) set plays role: fathership:father as parentship:parent
+    When entity(man) set plays role: fathership:father as parent
 
   Scenario: Entity types cannot redeclare inherited/overridden playing role types
     When put relation type: parentship
@@ -1173,7 +1173,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parentship:parent
+    When entity(man) set plays role: fathership:father as parent
     When put entity type: boy
     When entity(boy) set supertype: man
     When transaction commits
@@ -1190,7 +1190,7 @@ Feature: Concept Entity Type
     When relation(fathership) set relates role: father as parent
     When put entity type: person
     When entity(person) set plays role: parentship:parent
-    Then entity(person) set plays role: fathership:father as parentship:parent; throws exception
+    Then entity(person) set plays role: fathership:father as parent; throws exception
 
   Scenario: Entity types cannot override inherited playing role types other than with their subtypes
     When put relation type: parentship
@@ -1203,4 +1203,4 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:child
     When put entity type: man
     When entity(man) set supertype: person
-    Then entity(man) set plays role: fathership:father as parentship:parent; throws exception
+    Then entity(man) set plays role: fathership:father as parent; throws exception

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -1099,7 +1099,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:child
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     Then entity(man) get playing roles contain:
       | fathership:father |
       | parentship:child  |
@@ -1117,7 +1117,7 @@ Feature: Concept Entity Type
     When relation(mothership) set relates role: mother as parent
     When put entity type: woman
     When entity(woman) set supertype: person
-    When entity(woman) set plays role: mothership:mother as parent
+    When entity(woman) set plays role: mothership:mother as parentship:parent
     Then entity(woman) get playing roles contain:
       | mothership:mother |
       | parentship:child  |
@@ -1158,10 +1158,10 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     When transaction commits
     When session opens transaction of type: write
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
 
   Scenario: Entity types cannot redeclare inherited/overridden playing role types
     When put relation type: parentship
@@ -1173,7 +1173,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: parentship:parent
     When put entity type: man
     When entity(man) set supertype: person
-    When entity(man) set plays role: fathership:father as parent
+    When entity(man) set plays role: fathership:father as parentship:parent
     When put entity type: boy
     When entity(boy) set supertype: man
     When transaction commits

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -1151,7 +1151,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
     Then relation(contractor-employment) get playing roles do not contain:
       | locates:located |
     When transaction commits
@@ -1164,7 +1164,7 @@ Feature: Concept Relation Type and Role Type
     When relation(parttime-employment) set supertype: contractor-employment
     When relation(parttime-employment) set relates role: parttime-employer
     When relation(parttime-employment) set relates role: parttime-employee
-    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-located
+    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-locates:contractor-located
     Then relation(parttime-employment) get playing roles do not contain:
       | locates:located                       |
       | contractor-locates:contractor-located |
@@ -1187,7 +1187,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
     When transaction commits
@@ -1208,7 +1208,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set relates role: employer
     When relation(employment) set relates role: employee
     When relation(employment) set plays role: locates:located
-    Then relation(employment) set plays role: employment-locates:employment-located as located; throws exception
+    Then relation(employment) set plays role: employment-locates:employment-located as locates:located; throws exception
 
   Scenario: Relation types cannot override inherited playing role types other than with their subtypes
     When put relation type: locates
@@ -1223,4 +1223,4 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    Then relation(contractor-employment) set plays role: contractor-locates:contractor-located as located; throws exception
+    Then relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located; throws exception

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -1151,7 +1151,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
     Then relation(contractor-employment) get playing roles do not contain:
       | locates:located |
     When transaction commits
@@ -1164,7 +1164,7 @@ Feature: Concept Relation Type and Role Type
     When relation(parttime-employment) set supertype: contractor-employment
     When relation(parttime-employment) set relates role: parttime-employer
     When relation(parttime-employment) set relates role: parttime-employee
-    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-located
+    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-locates:contractor-located
     Then relation(parttime-employment) get playing roles do not contain:
       | locates:located                       |
       | contractor-locates:contractor-located |
@@ -1187,7 +1187,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
     When transaction commits

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -36,8 +36,8 @@ Feature: Concept Relation Type and Role Type
     Then relation(marriage) get role(husband) get supertype: relation:role
     Then relation(marriage) get role(wife) get supertype: relation:role
     Then relation(marriage) get related roles contain:
-      | husband |
-      | wife    |
+      | marriage:husband |
+      | marriage:wife    |
     When transaction commits
     When session opens transaction of type: read
     Then relation(marriage) is null: false
@@ -47,8 +47,8 @@ Feature: Concept Relation Type and Role Type
     Then relation(marriage) get role(husband) get supertype: relation:role
     Then relation(marriage) get role(wife) get supertype: relation:role
     Then relation(marriage) get related roles contain:
-      | husband |
-      | wife    |
+      | marriage:husband |
+      | marriage:wife    |
 
   Scenario: Relation and role types can be deleted
     When put relation type: marriage

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -1151,7 +1151,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
     Then relation(contractor-employment) get playing roles do not contain:
       | locates:located |
     When transaction commits
@@ -1164,7 +1164,7 @@ Feature: Concept Relation Type and Role Type
     When relation(parttime-employment) set supertype: contractor-employment
     When relation(parttime-employment) set relates role: parttime-employer
     When relation(parttime-employment) set relates role: parttime-employee
-    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-locates:contractor-located
+    When relation(parttime-employment) set plays role: parttime-locates:parttime-located as contractor-located
     Then relation(parttime-employment) get playing roles do not contain:
       | locates:located                       |
       | contractor-locates:contractor-located |
@@ -1187,7 +1187,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located
+    When relation(contractor-employment) set plays role: contractor-locates:contractor-located as located
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
     When transaction commits
@@ -1208,7 +1208,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set relates role: employer
     When relation(employment) set relates role: employee
     When relation(employment) set plays role: locates:located
-    Then relation(employment) set plays role: employment-locates:employment-located as locates:located; throws exception
+    Then relation(employment) set plays role: employment-locates:employment-located as located; throws exception
 
   Scenario: Relation types cannot override inherited playing role types other than with their subtypes
     When put relation type: locates
@@ -1223,4 +1223,4 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set plays role: locates:located
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    Then relation(contractor-employment) set plays role: contractor-locates:contractor-located as locates:located; throws exception
+    Then relation(contractor-employment) set plays role: contractor-locates:contractor-located as located; throws exception

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -126,13 +126,17 @@ Feature: Connection Database
     Then connection does not have any database
 
 
+  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see client-java#225)
+  @ignore
   Scenario: delete a database causes open sessions to fail
     When connection create database: grakn
     When connection open session for database: grakn
     When connection delete database: grakn
     Then connection does not have database: grakn
-    Then session, open transaction of type; throws exception: write
+    Then session open transaction of type; throws exception: write
 
+
+  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see client-java#225)
   @ignore
   Scenario: delete a database causes open transactions to fail
     When connection create database: grakn
@@ -147,4 +151,3 @@ Feature: Connection Database
 
   Scenario: delete a nonexistent database throws an error
     When connection delete database; throws exception: grakn
-    

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -146,7 +146,7 @@ Feature: Connection Session
       | eve     |
       | frank   |
 
-  @ignore-client-java
+
   Scenario: write schema in a data session throws
     When connection create database: grakn
     Given connection open data session for database: grakn
@@ -156,7 +156,7 @@ Feature: Connection Session
       define person sub entity;
       """
 
-  @ignore-client-java
+
   Scenario: write data in a schema session throws
     When connection create database: grakn
     Given connection open schema session for database: grakn


### PR DESCRIPTION
## What is the goal of this PR?

There was an inconsistency in our Behaviour tests: some referred to overridden role types by their label, others used the scoped label. We unified them to always use the scoped label.

## What are the changes implemented in this PR?

- Make steps that use overridden role types always refer to them by scoped label
- Ignore a database test that throws in `@After`
- Unignore session tests that were fixed in client-java
