### PR TITLE
Split 'graql match' step into aggregate, group, etc.

### DIFF
--- a/graql/explanation/language.feature
+++ b/graql/explanation/language.feature
@@ -45,7 +45,7 @@ Feature: Graql Reasoning Explanation
       $p isa person, has name "Alice";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $p isa person;
       """
@@ -89,7 +89,7 @@ Feature: Graql Reasoning Explanation
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
       $k isa area, has name $n;
@@ -146,7 +146,7 @@ Feature: Graql Reasoning Explanation
       (superior: $cou, subordinate: $cit) isa location-hierarchy;
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
       $k isa area, has name $n;
@@ -199,7 +199,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company, has name $n; not { $n "the-company"; };
       """
@@ -246,7 +246,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
@@ -294,7 +294,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; {$n2 "another-company";} or {$n2 "third-company";};};

--- a/graql/explanation/reasoner.feature
+++ b/graql/explanation/reasoner.feature
@@ -52,7 +52,7 @@ Feature: Graql Reasoning Explanation
       $x isa company, has company-id 0;
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $co has name $n;
       """
@@ -114,7 +114,7 @@ Feature: Graql Reasoning Explanation
       $co isa company, has company-id 0;
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $co has is-liable $l;
       """
@@ -180,7 +180,7 @@ Feature: Graql Reasoning Explanation
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
       $k isa area, has name $n;
@@ -275,7 +275,7 @@ Feature: Graql Reasoning Explanation
       | a-man-is-called-bob  | { $man isa man; };                                                                  | { $man has name "Bob"; };                         |
       | bobs-sister-is-alice | { $p isa man, has name $nb; $nb "Bob"; $p1 isa woman, has name $na; $na "Alice"; }; | { (sibling: $p, sibling: $p1) isa siblingship; }; |
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match ($w, $m) isa family-relation; $w isa woman;
       """
@@ -292,7 +292,7 @@ Feature: Graql Reasoning Explanation
       | 3 | -        | p1, na        | ALI, ALIN            | lookup               | { $p1 isa woman; $p1 has name $na; $na = "Alice"; $p1 iid <answer.p1.iid>; $na iid <answer.na.iid>; };                                                                                            |
       | 4 | -        | man           | BOB                  | lookup               | { $man isa man; $man iid <answer.man.iid>; };                                                                                                                                                      |
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match (sibling: $w, sibling: $m) isa siblingship; $w isa woman;
       """
@@ -348,7 +348,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
@@ -413,7 +413,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company, has is-liable $lia; $lia true;
       """
@@ -477,7 +477,7 @@ Feature: Graql Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };
       """

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -54,7 +54,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type dog;
       """
@@ -71,7 +71,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub person;
       """
@@ -137,7 +137,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays employment:employee;
       """
@@ -158,7 +158,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays employment:employee;
       """
@@ -178,7 +178,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -199,7 +199,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -219,7 +219,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns email @key;
       """
@@ -240,7 +240,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns email @key;
       """
@@ -263,7 +263,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays home-ownership:home;
       """
@@ -282,7 +282,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns price;
       """
@@ -301,7 +301,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns address @key;
       """
@@ -383,7 +383,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type pet-ownership;
       """
@@ -400,7 +400,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub employment;
       """
@@ -427,7 +427,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates employee;
       """
@@ -450,7 +450,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x relates parent;
@@ -459,7 +459,7 @@ Feature: Graql Define Query
     Then uniquely identify answer concepts
       | x                 |
       | label:parenthood |
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x relates father;
@@ -480,7 +480,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
       $x sub parenthood:parent; $y sub parenthood:child; get $x, $y;
@@ -501,7 +501,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates employee;
       """
@@ -527,7 +527,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays income:source;
       """
@@ -548,7 +548,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays income:source;
       """
@@ -568,7 +568,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns start-date;
       """
@@ -589,7 +589,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns start-date;
       """
@@ -609,7 +609,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns employment-reference-code @key;
       """
@@ -630,7 +630,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns employment-reference-code @key;
       """
@@ -650,7 +650,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type connection;
       """
@@ -669,7 +669,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates parent; $x relates child;
       """
@@ -688,7 +688,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates owner;
       """
@@ -710,7 +710,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type <label>;
@@ -753,7 +753,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub code;
       """
@@ -773,7 +773,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type door-code, value string;
       """
@@ -798,7 +798,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x regex "^(yes|no|maybe)$";
       """
@@ -827,7 +827,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays car-sales-listing:available-colour;
       """
@@ -851,7 +851,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays phone-contact:number;
       """
@@ -874,7 +874,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns brightness;
       """
@@ -897,7 +897,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns country-calling-code;
       """
@@ -920,7 +920,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns hex-value @key;
       """
@@ -943,7 +943,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns hex-value @key;
       """
@@ -965,7 +965,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns <label>;
       """
@@ -1005,7 +1005,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type animal; $x abstract;
       """
@@ -1024,7 +1024,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub animal;
       """
@@ -1044,7 +1044,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub animal; $x abstract;
       """
@@ -1064,7 +1064,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub exception, abstract;
       """
@@ -1081,7 +1081,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type membership; $x abstract;
       """
@@ -1100,7 +1100,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub membership;
       """
@@ -1120,7 +1120,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub requirement; $x abstract;
       """
@@ -1140,7 +1140,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub requirement; $x abstract;
       """
@@ -1157,7 +1157,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type number-of-limbs; $x abstract;
       """
@@ -1176,7 +1176,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub number-of-limbs;
       """
@@ -1196,7 +1196,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub number-of-limbs; $x abstract;
       """
@@ -1219,7 +1219,7 @@ Feature: Graql Define Query
       """
     Then transaction commits
     Then session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
       $name type name; $name abstract;
@@ -1254,7 +1254,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type person, owns name;
       """
@@ -1295,7 +1295,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -1313,7 +1313,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays employment:employee;
       """
@@ -1354,7 +1354,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns barcode @key;
       """
@@ -1435,7 +1435,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates employer;
       """
@@ -1465,7 +1465,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Then session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $x regex "^A.*$";
       """
@@ -1542,7 +1542,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name @key;
       """
@@ -1559,14 +1559,14 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns email;
       """
     Then uniquely identify answer concepts
       | x            |
       | label:person |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns email @key;
       """
@@ -1615,7 +1615,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub person; $x abstract;
       """
@@ -1632,7 +1632,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub employment; $x abstract;
       """
@@ -1649,7 +1649,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub name; $x abstract;
       """
@@ -1735,7 +1735,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub apple-product;
       """
@@ -1779,7 +1779,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub shoe-size;
       """
@@ -1809,7 +1809,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub organism;
       """
@@ -1850,7 +1850,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub pigeon;
       """
@@ -1890,7 +1890,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub pigeon;
       """
@@ -1930,7 +1930,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub pigeon;
       """
@@ -1975,7 +1975,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child, plays $r;
       """
@@ -1997,7 +1997,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child, owns $y;
       """
@@ -2018,7 +2018,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child, owns $y @key;
       """
@@ -2038,7 +2038,7 @@ Feature: Graql Define Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type part-time-employment, relates $r;
       """
@@ -2096,7 +2096,7 @@ Feature: Graql Define Query
       middlename sub attribute, value string, owns firstname;
       firstname sub attribute, value string, owns surname;
       """
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $a sub attribute, owns $b; $b sub attribute, owns $a;
       """
@@ -2104,7 +2104,7 @@ Feature: Graql Define Query
       | a              | b              |
       | label:nickname | label:surname  |
       | label:surname  | label:nickname |
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $a owns $b; $b owns $a;
       """
@@ -2122,7 +2122,7 @@ Feature: Graql Define Query
       middlename sub attribute, value string, owns firstname;
       firstname sub attribute, value string, owns surname;
       """
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
       $a sub attribute, owns $b;
@@ -2148,7 +2148,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates function; $x plays recursive-function:function;
       """
@@ -2165,7 +2165,7 @@ Feature: Graql Define Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns number-of-letters;
       """

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -76,19 +76,19 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
     Then uniquely identify answer concepts
       | x            |
       | key:name:Bob |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa friendship;
       """
     Then answer size is: 0
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -124,7 +124,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -159,7 +159,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -194,7 +194,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa friendship;
       """
@@ -223,7 +223,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -256,7 +256,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -288,7 +288,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -402,7 +402,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match (friend: $x, friend: $y) isa friendship;
       """
@@ -441,7 +441,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match (friend: $x, friend: $y) isa friendship;
       """
@@ -495,7 +495,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match (special-friend: $x, special-friend: $y) isa friendship;
       """
@@ -533,7 +533,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -541,7 +541,7 @@ Feature: Graql Delete Query
       | x               |
       | key:name:Bob    |
       | key:name:Carrie |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x) isa friendship;
       """
@@ -575,7 +575,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x) isa friendship;
       """
@@ -608,7 +608,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -644,7 +644,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -679,7 +679,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -718,7 +718,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (friend: $x) isa friendship;
       """
@@ -776,7 +776,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa friendship;
       """
@@ -810,7 +810,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa friendship;
       """
@@ -940,7 +940,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $rel (chef: $p) isa ship-crew;
       """
@@ -957,7 +957,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $rel (chef: $p) isa ship-crew;
       """
@@ -991,7 +991,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age 18;
       """
@@ -1008,7 +1008,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age 18;
       """
@@ -1057,7 +1057,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -1065,14 +1065,14 @@ Feature: Graql Delete Query
       | x             |
       | key:name:Alex |
       | key:name:John |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $n isa lastname;
       """
     Then uniquely identify answer concepts
       | n                    |
       | value:lastname:Smith |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has lastname $n;
       """
@@ -1108,7 +1108,7 @@ Feature: Graql Delete Query
       | x                 |
       | key:name:Sherlock |
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has attribute $a;
       """
@@ -1127,7 +1127,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has attribute $a;
       """
@@ -1160,7 +1160,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has address $a;
       """
@@ -1177,7 +1177,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has address $a;
       """
@@ -1240,7 +1240,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -1291,7 +1291,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has duration $d;
       """
@@ -1308,7 +1308,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has duration $d;
       """
@@ -1339,7 +1339,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has duration $d;
       """
@@ -1356,12 +1356,12 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has duration $d;
       """
     Then answer size is: 0
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa friendship;
       """
@@ -1429,7 +1429,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $f (friend: $x) isa friendship;
       """
@@ -1438,7 +1438,7 @@ Feature: Graql Delete Query
       | key:ref:1   | key:name:Alex |
       | key:ref:2   | key:name:John |
       | key:ref:3   | key:name:Alex |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $n isa name;
       """
@@ -1446,7 +1446,7 @@ Feature: Graql Delete Query
       | n               |
       | value:name:John |
       | value:name:Alex |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has lastname $n;
       """
@@ -1502,7 +1502,7 @@ Feature: Graql Delete Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has lastname $n;
       """
@@ -1552,7 +1552,7 @@ Feature: Graql Delete Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -423,7 +423,7 @@ Feature: Graql Get Clause
         $f isa friendship;
       """
     Then answer size is: 9
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match
         $x isa person;
@@ -440,7 +440,7 @@ Feature: Graql Get Clause
         $f (friend: $x) isa friendship;
       """
     Then answer size is: 6
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match
         $x isa person;
@@ -452,7 +452,7 @@ Feature: Graql Get Clause
 
 
   Scenario: the 'count' of an empty answer set is zero
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has name "Voldemort";
       count;
@@ -485,7 +485,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has <attr> $y;
       <agg_type> $y;
@@ -531,7 +531,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has weight $y;
       std $y;
@@ -551,13 +551,13 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has name $y, has age $z;
       sum $z;
       """
     Then aggregate value is: 65
-    Then get answer of graql aggregate
+    Then get answer of graql match aggregate
       """
       match $x isa person, has name $y, has age $z;
       get $y, $z;
@@ -576,7 +576,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has age $y;
       <agg_type> $y;
@@ -601,7 +601,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has age $y;
       median $y;
@@ -622,7 +622,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has income $y;
       <agg_type> $y;
@@ -743,7 +743,7 @@ Feature: Graql Get Clause
 
 
   Scenario: when taking the sum of an empty set, even if any matches would definitely be strings, no error is thrown and an empty answer is returned
-    When get answer of graql aggregate
+    When get answer of graql match aggregate
       """
       match $x isa person, has name $y;
       sum $y;

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -71,7 +71,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $z isa person, has name $x, has age $y;
@@ -119,7 +119,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa <attr>;
       sort $x asc;
@@ -151,7 +151,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -162,7 +162,7 @@ Feature: Graql Get Clause
       | key:ref:2 | value:name:Frederick |
       | key:ref:0 | value:name:Gary      |
       | key:ref:1 | value:name:Jemima    |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y desc;
@@ -187,7 +187,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y;
@@ -212,7 +212,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -237,7 +237,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -261,7 +261,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -286,7 +286,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -307,7 +307,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name $y;
       sort $y asc;
@@ -329,7 +329,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $x isa name;
       sort $x asc;
@@ -356,7 +356,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has age $y;
       sort $y asc;
@@ -366,7 +366,7 @@ Feature: Graql Get Clause
       | x         | y           |
       | key:ref:0 | value:age:2 |
       | key:ref:4 | value:age:2 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has age $y;
       sort $y asc;
@@ -415,7 +415,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa person;
@@ -423,7 +423,7 @@ Feature: Graql Get Clause
         $f isa friendship;
       """
     Then answer size is: 9
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match
         $x isa person;
@@ -432,7 +432,7 @@ Feature: Graql Get Clause
       count;
       """
     Then aggregate value is: 9
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa person;
@@ -440,7 +440,7 @@ Feature: Graql Get Clause
         $f (friend: $x) isa friendship;
       """
     Then answer size is: 6
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match
         $x isa person;
@@ -452,7 +452,7 @@ Feature: Graql Get Clause
 
 
   Scenario: the 'count' of an empty answer set is zero
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has name "Voldemort";
       count;
@@ -485,7 +485,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has <attr> $y;
       <agg_type> $y;
@@ -531,7 +531,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has weight $y;
       std $y;
@@ -551,13 +551,13 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has name $y, has age $z;
       sum $z;
       """
     Then aggregate value is: 65
-    Then get answers of graql query
+    Then get answer of graql aggregate
       """
       match $x isa person, has name $y, has age $z;
       get $y, $z;
@@ -576,7 +576,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has age $y;
       <agg_type> $y;
@@ -601,7 +601,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has age $y;
       median $y;
@@ -622,7 +622,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has income $y;
       <agg_type> $y;
@@ -743,7 +743,7 @@ Feature: Graql Get Clause
 
 
   Scenario: when taking the sum of an empty set, even if any matches would definitely be strings, no error is thrown and an empty answer is returned
-    When get answers of graql query
+    When get answer of graql aggregate
       """
       match $x isa person, has name $y;
       sum $y;
@@ -768,7 +768,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match ($x, $y) isa friendship;
       """
@@ -786,7 +786,7 @@ Feature: Graql Get Clause
       | key:ref:3 | key:ref:0 |
       | key:ref:3 | key:ref:1 |
       | key:ref:3 | key:ref:2 |
-    When get answers of graql query
+    When get answers of graql match group
       """
       match ($x, $y) isa friendship;
       group $x;
@@ -844,11 +844,11 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
-    When get answers of graql query
+    When get answers of graql match group aggregate
       """
       match ($x, $y) isa friendship;
       group $x;
@@ -876,7 +876,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
       $x isa company;
@@ -894,7 +894,7 @@ Feature: Graql Get Clause
       | key:ref:0 | key:ref:3 | key:ref:4 |
       | key:ref:1 | key:ref:4 | key:ref:2 |
       | key:ref:1 | key:ref:4 | key:ref:3 |
-    Then get answers of graql query
+    Then get answers of graql match group aggregate
       """
       match
         $x isa company;
@@ -928,7 +928,7 @@ Feature: Graql Get Clause
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match group aggregate
       """
       match
         $x isa company;

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -73,7 +73,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -92,7 +92,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -113,21 +113,21 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name "Bond";
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name "James Bond";
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name "Bond", has name "James Bond";
       """
@@ -151,7 +151,7 @@ Feature: Graql Insert Query
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa dog;
       """
@@ -163,7 +163,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa dog;
       """
@@ -175,7 +175,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa dog;
       """
@@ -187,7 +187,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa dog;
       """
@@ -240,7 +240,7 @@ Feature: Graql Insert Query
   #######################
 
   Scenario: when inserting a new thing that owns new attributes, both the thing and the attributes get created
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa thing;
       """
@@ -252,7 +252,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa thing;
       """
@@ -272,7 +272,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name "John";
       """
@@ -294,7 +294,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name "Kyle";
       """
@@ -313,7 +313,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
       $p1 isa person, has age $a;
@@ -355,7 +355,7 @@ Feature: Graql Insert Query
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p isa dog;
       """
@@ -370,7 +370,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p isa dog;
       """
@@ -402,7 +402,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p isa person, has <attr> $x; get $x;
       """
@@ -442,7 +442,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $p has name "Spiderman";
       """
@@ -457,7 +457,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p has name "Spiderman";
       """
@@ -475,7 +475,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $p has name "Spiderman";
       """
@@ -490,7 +490,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p has name "Spiderman";
       """
@@ -522,7 +522,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $c has hex-value "#FF0000";
       """
@@ -537,7 +537,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $c has hex-value "#FF0000";
       """
@@ -569,7 +569,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $c has hex-value "#FF0000";
       """
@@ -584,7 +584,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $c has hex-value "#FF0000";
       """
@@ -624,7 +624,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $td isa tenure-days;
       """
@@ -639,7 +639,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa residence, has tenure-days $a; get $a;
       """
@@ -674,7 +674,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $p has age 32;
       """
@@ -691,7 +691,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $p has age 32;
       """
@@ -714,7 +714,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (employee: $p) isa employment;
       """
@@ -755,7 +755,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (place-of-residence: $addr) isa residence, has is-permanent $perm;
       """
@@ -776,7 +776,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $r (employer: $c) isa employment;
@@ -786,7 +786,7 @@ Feature: Graql Insert Query
     Then uniquely identify answer concepts
       | cname                  |
       | value:name:Morrisons   |
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $r (employee: $p) isa employment;
@@ -815,7 +815,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
@@ -847,7 +847,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
@@ -876,7 +876,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (employee: $p, employee: $p) isa employment;
       """
@@ -969,7 +969,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match (member: $p) isa gym-membership; get $p;
       """
@@ -983,14 +983,14 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match (member: $p) isa gym-membership; get $p;
       """
     Then uniquely identify answer concepts
       | p         |
       | key:ref:0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa gym-membership; get $r;
       """
@@ -1014,7 +1014,7 @@ Feature: Graql Insert Query
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x <value> isa <attr>;
       """
@@ -1026,7 +1026,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x <value> isa <attr>;
       """
@@ -1080,7 +1080,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa age;
       """
@@ -1112,7 +1112,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa length;
       """
@@ -1152,7 +1152,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa length;
       """
@@ -1185,7 +1185,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa length;
       """
@@ -1215,7 +1215,7 @@ Feature: Graql Insert Query
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x <match> isa <attr>;
       """
@@ -1333,7 +1333,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -1466,7 +1466,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has is-cool true;
       """
@@ -1535,7 +1535,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x has height $z;
@@ -1561,7 +1561,7 @@ Feature: Graql Insert Query
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $p isa person;
       """
@@ -1576,7 +1576,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r isa season-ticket-ownership;
       """
@@ -1597,7 +1597,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa person;
       """
@@ -1616,7 +1616,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -1645,7 +1645,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $r (employee: $x, employer: $c) isa employment;
       """
@@ -1664,7 +1664,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (employee: $x, employer: $c) isa employment;
       """
@@ -1689,7 +1689,7 @@ Feature: Graql Insert Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa name;
       """
@@ -1708,7 +1708,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -1738,7 +1738,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -1794,12 +1794,12 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa! child;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa! person;
       """
@@ -1842,7 +1842,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -1859,7 +1859,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -1899,7 +1899,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has score $score;
       """
@@ -1917,7 +1917,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa score;
       """
@@ -1925,7 +1925,7 @@ Feature: Graql Insert Query
     Then uniquely identify answer concepts
       | x                |
       | value:score:10.0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has score $score;
       """
@@ -1977,7 +1977,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -2007,12 +2007,12 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
     Then answer size is: 0
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa name;
       """
@@ -2020,7 +2020,7 @@ Feature: Graql Insert Query
     Then uniquely identify answer concepts
       | x                 |
       | value:name:Ganesh |
-    When get answers of graql query
+    When get answers of graql match
       """
       match (lettered-name: $x, initial: $y) isa name-initial;
       """
@@ -2076,7 +2076,7 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa employment;
       """
@@ -2103,13 +2103,13 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa employment;
       """
     # We deleted the rule that infers the employment, but it still exists because it was materialised on match-insert
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match (contracted: $x, contract: $y) isa employment-contract;
       """
@@ -2215,7 +2215,7 @@ Feature: Graql Insert Query
     # After deleting all the links to 'c', our rules no longer infer that 'd' is reachable from 'a'. But in fact we
     # materialised this reachable link when we did our match-insert, because it played a role in our road-proposal,
     # which itself plays a role in the road-construction that we explicitly inserted:
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $a isa vertex, has index "a";
@@ -2226,7 +2226,7 @@ Feature: Graql Insert Query
     # On the other hand, the fact that 'c' was reachable from 'a' was not -directly- used; although it was needed
     # in order to infer that (a,d) was reachable, it did not, itself, play a role in any relation that we materialised,
     # so it is now gone.
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $a isa vertex, has index "a";
@@ -2333,12 +2333,12 @@ Feature: Graql Insert Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
     Then answer size is: 64
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa employment;
       """
@@ -2409,7 +2409,7 @@ Feature: Graql Insert Query
     Then the integrity is validated
     When session opens transaction of type: read
     Then the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -2433,7 +2433,7 @@ Feature: Graql Insert Query
       """
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name "Derek";
       """
@@ -2465,7 +2465,7 @@ Feature: Graql Insert Query
       $y isa person, has name "Emily", has capacity 1000;
       """
     Then the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name "Derek";
       """
@@ -2485,7 +2485,7 @@ Feature: Graql Insert Query
       """
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name "Derek";
       """

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -68,7 +68,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type person;
       """
@@ -87,7 +87,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub person;
       """
@@ -108,7 +108,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match writer sub $x;
       """
@@ -155,7 +155,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa $type;
@@ -191,7 +191,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub! person;
       """
@@ -211,7 +211,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match writer sub! $x;
       """
@@ -236,7 +236,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x sub $y;
@@ -250,7 +250,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'owns' matches types that own the specified attribute type
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns age;
       """
@@ -268,7 +268,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns $x;
       """
@@ -288,7 +288,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -309,7 +309,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns club-name;
       """
@@ -319,7 +319,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'owns' can be used to match attribute types that a given type owns
-    When get answers of graql query
+    When get answers of graql match
       """
       match person owns $x;
       """
@@ -352,7 +352,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa $type;
@@ -367,7 +367,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'plays' matches types that can play the specified role
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays friendship:friend;
       """
@@ -386,7 +386,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays friendship:friend;
       """
@@ -405,7 +405,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays close-friendship:close-friend;
       """
@@ -415,7 +415,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'plays' can be used to match roles that a particular type can play
-    When get answers of graql query
+    When get answers of graql match
       """
       match person plays $x;
       """
@@ -448,7 +448,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa $type;
@@ -470,7 +470,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns breed @key;
       """
@@ -480,7 +480,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'key' can be used to find all attribute types that a given type owns as a key
-    When get answers of graql query
+    When get answers of graql match
       """
       match person owns $x @key;
       """
@@ -500,7 +500,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns breed;
       """
@@ -511,7 +511,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'relates' matches relation types where the specified role can be played
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates employee;
       """
@@ -531,7 +531,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates close-friend as friend;
       """
@@ -550,7 +550,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates friend;
       """
@@ -560,7 +560,7 @@ Feature: Graql Match Query
 
 
   Scenario: 'relates' can be used to retrieve all the roles of a relation type
-    When get answers of graql query
+    When get answers of graql match
       """
       match employment relates $x;
       """
@@ -573,7 +573,7 @@ Feature: Graql Match Query
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
   @ignore
   Scenario: when matching by a concept iid that doesn't exist, an empty result is returned
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x iid 0x83cb2;
@@ -599,7 +599,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa $y;
       """
@@ -642,7 +642,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa writer;
       """
@@ -677,7 +677,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa! writer;
       """
@@ -698,7 +698,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person;
       """
@@ -709,7 +709,7 @@ Feature: Graql Match Query
 
 
   Scenario: match returns an empty answer if there are no matches
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person, has name "Anonymous Coward";
       """
@@ -754,7 +754,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa person;
@@ -815,14 +815,14 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $x isa person; $r (employee: $x) isa relation;
       """
     Then uniquely identify answer concepts
       | x         | r         |
       | key:ref:0 | key:ref:2 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $y isa company; $r (employer: $y) isa relation;
       """
@@ -846,7 +846,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa person; $r ($x) isa relation;
       """
@@ -869,7 +869,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $r ($x, $y) isa employment;
       """
@@ -902,7 +902,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (player: $x, player: $x) isa relation;
       """
@@ -930,7 +930,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $r (player: $x) isa relation;
       """
@@ -953,7 +953,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match (friend: $x, friend: $x) isa friendship;
       """
@@ -993,7 +993,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         (sender: $a, recipient: $b) isa gift-delivery;
@@ -1002,7 +1002,7 @@ Feature: Graql Match Query
     Then uniquely identify answer concepts
       | a         | b         | c         |
       | key:ref:0 | key:ref:1 | key:ref:2 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         (sender: $a, recipient: $b) isa gift-delivery;
@@ -1037,7 +1037,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $r isa relation;
       """
@@ -1046,14 +1046,14 @@ Feature: Graql Match Query
       | key:ref:1 |
       | key:ref:2 |
       | key:ref:3 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match ($x) isa relation;
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of graql query
+    When get answers of graql match
       """
       match ($x);
       """
@@ -1141,7 +1141,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (wife: $x, husband: $y) isa hetero-marriage;
       """
@@ -1152,52 +1152,52 @@ Feature: Graql Match Query
       """
     Then session transaction is open: false
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (wife: $x, husband: $y) isa marriage;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (wife: $x, husband: $y) isa relation;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (spouse: $x, spouse: $y) isa hetero-marriage;
       """
     Then answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (spouse: $x, spouse: $y) isa civil-marriage;
       """
     Then answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (spouse: $x, spouse: $y) isa marriage;
       """
     Then answer size is: 4
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (spouse: $x, spouse: $y) isa relation;
       """
     Then answer size is: 4
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (role: $x, role: $y) isa hetero-marriage;
       """
     Then answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (role: $x, role: $y) isa civil-marriage;
       """
     Then answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (role: $x, role: $y) isa marriage;
       """
     Then answer size is: 4
-    When get answers of graql query
+    When get answers of graql match
       """
       match $m (role: $x, role: $y) isa relation;
       """
@@ -1225,7 +1225,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $a <value>;
       """
@@ -1250,7 +1250,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $a <value>;
       """
@@ -1279,7 +1279,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x contains "Fun";
       """
@@ -1303,7 +1303,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x contains "Bean";
       """
@@ -1327,7 +1327,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x like "^[0-9]+$";
       """
@@ -1340,12 +1340,12 @@ Feature: Graql Match Query
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
   @ignore
   Scenario: when querying for a non-existent attribute type iid, an empty result is returned
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name $y; $x iid 0x83cb2;
       """
     Then answer size is: 0
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name $y; $y iid 0x83cb2;
       """
@@ -1367,7 +1367,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
       $x isa person, has $n;
@@ -1393,7 +1393,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has name $y; get $x;
       """
@@ -1425,7 +1425,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has attribute 9;
       """
@@ -1461,7 +1461,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age 21;
       """
@@ -1492,7 +1492,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has lucky-number 20;
       """
@@ -1520,7 +1520,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has $x;
       """
@@ -1587,7 +1587,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
         $x isa person, has graduation-date $date;
@@ -1613,7 +1613,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age = 16;
       """
@@ -1636,7 +1636,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age > 18;
       """
@@ -1659,7 +1659,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age < 18;
       """
@@ -1682,7 +1682,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has age != 18;
       """
@@ -1713,42 +1713,42 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa house-number;
         $x = 1.0;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa length;
         $x = 2;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa house-number;
         $x 1.0;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa length;
         $x 2;
       """
     Then answer size is: 1
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa attribute;
         $x >= 1;
       """
     Then answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa attribute;
@@ -1777,7 +1777,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x has lucky-number > 25;
       """
@@ -1800,7 +1800,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x has age = $z;
@@ -1836,7 +1836,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa attribute;
@@ -1859,7 +1859,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x isa person;
@@ -1892,7 +1892,7 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match {$x isa person;} or {$x isa company;};
       """
@@ -1920,22 +1920,22 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa entity;
       """
     Given answer size is: 2
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $r isa relation;
       """
     Given answer size is: 1
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x isa attribute;
       """
     Given answer size is: 5
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa $type;
       """
@@ -1959,18 +1959,18 @@ Feature: Graql Match Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: read
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $r isa relation;
       """
     Given answer size is: 1
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match ($x, $y) isa relation;
       """
     # 2 permutations of the roleplayers
     Given answer size is: 2
-    When get answers of graql query
+    When get answers of graql match
       """
       match ($x, $y) isa $type;
       """
@@ -2004,7 +2004,7 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
   Scenario: the first variable in a negation can be unbound, as long as it is connected to a bound variable
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
         $r isa attribute;
@@ -2015,7 +2015,7 @@ Feature: Graql Match Query
 
   # TODO: We should verify the answers
   Scenario: negations can contain disjunctions
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match
         $x isa entity;

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -52,7 +52,7 @@ Feature: Graql Rule Validation
       };
       """
     Given the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub rule;
       """
@@ -74,7 +74,7 @@ Feature: Graql Rule Validation
       };
       """
     Given the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub rule;
       """
@@ -157,7 +157,7 @@ Feature: Graql Rule Validation
       };
       """
     Given the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub rule;
       """
@@ -284,7 +284,7 @@ Feature: Graql Rule Validation
       };
       """
     Given the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub rule;
       """

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -44,7 +44,7 @@ Feature: Graql Undefine Query
   ################
 
   Scenario: calling 'undefine' with 'sub entity' on a subtype of 'entity' deletes it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub entity;
       """
@@ -60,7 +60,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub entity;
       """
@@ -78,7 +78,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type person;
       """
@@ -95,7 +95,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub person;
       """
@@ -110,7 +110,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub person;
       """
@@ -134,7 +134,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child;
       """
@@ -173,7 +173,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child; $x plays employment:employee;
       """
@@ -195,7 +195,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child; $x owns name;
       """
@@ -217,7 +217,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type child; $x owns email @key;
       """
@@ -225,7 +225,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub entity;
       """
@@ -275,7 +275,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub entity;
       """
@@ -290,7 +290,7 @@ Feature: Graql Undefine Query
   ##################
 
   Scenario: undefining a relation type removes it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub relation;
       """
@@ -305,7 +305,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub relation;
       """
@@ -325,7 +325,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match contract-employment plays $x;
       """
@@ -339,7 +339,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match contract-employment plays $x;
       """
@@ -357,7 +357,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x owns start-date;
       """
@@ -372,7 +372,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns start-date;
       """
@@ -390,7 +390,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x owns employment-reference @key;
       """
@@ -405,7 +405,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns employment-reference @key;
       """
@@ -439,7 +439,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: all existing instances of a relation type must be deleted in order to undefine it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub relation;
       """
@@ -488,7 +488,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub relation;
       """
@@ -498,7 +498,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: undefining a relation type automatically detaches any possible roleplayers
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x type person;
@@ -514,7 +514,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type person;
@@ -528,7 +528,7 @@ Feature: Graql Undefine Query
   #############################
 
   Scenario: a role type can be removed from its relation type
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match employment relates $x;
       """
@@ -543,7 +543,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match employment relates $x;
       """
@@ -560,7 +560,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays employment:employee;
       """
@@ -603,7 +603,7 @@ Feature: Graql Undefine Query
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x relates employee;
       """
@@ -630,7 +630,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: undefining a role type automatically detaches any possible roleplayers
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x type person;
@@ -646,7 +646,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type person;
@@ -707,7 +707,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match employment relates $x;
       """
@@ -731,7 +731,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x type part-time; $x relates $role;
       """
@@ -784,7 +784,7 @@ Feature: Graql Undefine Query
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x plays employment:employee;
       """
@@ -800,7 +800,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: undefining a playable role that was not actually playable to begin with is a no-op
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match person plays $x;
       """
@@ -814,7 +814,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match person plays $x;
       """
@@ -857,7 +857,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x type <attr>;
       """
@@ -900,7 +900,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa email;
       """
@@ -927,7 +927,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match first-name plays $x;
       """
@@ -941,7 +941,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match first-name plays $x;
       """
@@ -960,7 +960,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x owns locale;
       """
@@ -975,7 +975,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns locale;
       """
@@ -994,7 +994,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x owns name-id @key;
       """
@@ -1009,7 +1009,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name-id @key;
       """
@@ -1049,7 +1049,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: all existing instances of an attribute type must be deleted in order to undefine it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1097,7 +1097,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1112,7 +1112,7 @@ Feature: Graql Undefine Query
   ########################
 
   Scenario: undefining an attribute ownership removes it
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x owns name;
@@ -1128,7 +1128,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x owns name;
@@ -1162,7 +1162,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -1180,7 +1180,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns email;
       """
@@ -1204,7 +1204,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: when a type can own an attribute, but none of its instances actually do, the ownership can be undefined
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x owns name;
       """
@@ -1232,7 +1232,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x owns name;
       """
@@ -1298,7 +1298,7 @@ Feature: Graql Undefine Query
     Given transaction commits
     Given the integrity is validated
     When session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub rule;
       """
@@ -1313,7 +1313,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    Then get answers of graql query
+    Then get answers of graql match
       """
       match $x sub rule;
       """
@@ -1342,7 +1342,7 @@ Feature: Graql Undefine Query
       """
     Given transaction commits
     Given the integrity is validated
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x has name $n;
@@ -1361,7 +1361,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x has name $n;
@@ -1395,7 +1395,7 @@ Feature: Graql Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x has name $n;
@@ -1409,7 +1409,7 @@ Feature: Graql Undefine Query
       undefine rule samuel-email-rule;
       """
     Then the integrity is validated
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x has name $n;
@@ -1425,7 +1425,7 @@ Feature: Graql Undefine Query
   ############
 
   Scenario: undefining a type as abstract converts an abstract to a concrete type, allowing creation of instances
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match
         $x type abstract-type;
@@ -1452,7 +1452,7 @@ Feature: Graql Undefine Query
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type abstract-type;
@@ -1468,7 +1468,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x isa abstract-type;
       """
@@ -1483,7 +1483,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type person;
@@ -1509,7 +1509,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type abstract-type;
@@ -1540,7 +1540,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match
         $x type vehicle-registration;
@@ -1554,7 +1554,7 @@ Feature: Graql Undefine Query
   ###################
 
   Scenario: a type and an attribute type that it owns can be removed simultaneously
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub entity;
       """
@@ -1563,7 +1563,7 @@ Feature: Graql Undefine Query
       | label:person        |
       | label:abstract-type |
       | label:entity        |
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1581,7 +1581,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub entity;
       """
@@ -1589,7 +1589,7 @@ Feature: Graql Undefine Query
       | x                   |
       | label:abstract-type |
       | label:entity        |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1600,7 +1600,7 @@ Feature: Graql Undefine Query
 
 
   Scenario: a type, a relation type that it plays in and an attribute type that it owns can be removed simultaneously
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub entity;
       """
@@ -1609,7 +1609,7 @@ Feature: Graql Undefine Query
       | label:person        |
       | label:abstract-type |
       | label:entity        |
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub relation;
       """
@@ -1617,7 +1617,7 @@ Feature: Graql Undefine Query
       | x                |
       | label:employment |
       | label:relation   |
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1626,7 +1626,7 @@ Feature: Graql Undefine Query
       | label:name      |
       | label:email     |
       | label:attribute |
-    Given get answers of graql query
+    Given get answers of graql match
       """
       match $x sub role;
       """
@@ -1645,7 +1645,7 @@ Feature: Graql Undefine Query
     Then transaction commits
     Then the integrity is validated
     When session opens transaction of type: read
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub entity;
       """
@@ -1653,14 +1653,14 @@ Feature: Graql Undefine Query
       | x                   |
       | label:abstract-type |
       | label:entity        |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub relation;
       """
     Then uniquely identify answer concepts
       | x              |
       | label:relation |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub attribute;
       """
@@ -1668,7 +1668,7 @@ Feature: Graql Undefine Query
       | x               |
       | label:email     |
       | label:attribute |
-    When get answers of graql query
+    When get answers of graql match
       """
       match $x sub role;
       """


### PR DESCRIPTION
## What is the goal of this PR?

The `get answers of graql query` step was problematic for Clients Python and NodeJS, because they don't have Graql parsing libraries - meaning they can't reliably figure out which query type the raw String corresponds to (from the feature file) To mitigate the issue, we split the step up into multiple steps: `get answers of graql match aggregate`, `get answers of graql match group`... and so on.

## What are the changes implemented in this PR?

- Split 'get answers of graql query' step into match, aggregate, group, group aggregate
