### PR TITLE
Temporarily disable all failing Graql Define tests

### DIFF
--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -983,14 +983,9 @@ Feature: Graql Define Query
 
 
   # TODO
-  Scenario Outline: a type can own a '<value_type>' attribute type as a key
-
-    Examples:
-
-  # TODO
-  Scenario Outline: a '<value_type>' attribute type is not allowed to be a key
-
-    Examples:
+#  Scenario Outline: a type can own a '<value_type>' attribute type as a key
+#
+#  Scenario Outline: a '<value_type>' attribute type is not allowed to be a key
 
 
   ##################

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -392,6 +392,8 @@ Feature: Graql Define Query
       | label:pet-ownership |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: a new relation type can be defined as a subtype, creating a new child of its parent type
     When graql define
       """
@@ -470,6 +472,8 @@ Feature: Graql Define Query
       | label:father-sonhood |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: when a relation type's role is overridden, it creates a sub-role of the parent role type
     When graql define
       """
@@ -790,6 +794,8 @@ Feature: Graql Define Query
     Then the integrity is validated
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: a regex constraint can be defined on a 'string' attribute type
     Given graql define
       """
@@ -1181,6 +1187,8 @@ Feature: Graql Define Query
       | label:number-of-legs  |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: an abstract attribute type can be defined as a subtype of another abstract attribute type
     When graql define
       """
@@ -1959,6 +1967,8 @@ Feature: Graql Define Query
   # SCHEMA MUTATION INHERITANCE #
   ###############################
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: when adding a playable role to an existing type, the change is propagated to its subtypes
     Given graql define
       """
@@ -1981,6 +1991,8 @@ Feature: Graql Define Query
       | label:child | label:earner   |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: when adding an attribute ownership to an existing type, the change is propagated to its subtypes
     Given graql define
     """
@@ -2002,6 +2014,8 @@ Feature: Graql Define Query
       | label:child | label:phone-number |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: when adding a key ownership to an existing type, the change is propagated to its subtypes
     Given graql define
       """
@@ -2023,6 +2037,8 @@ Feature: Graql Define Query
       | label:child | label:email |
 
 
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
   Scenario: when adding a related role to an existing relation type, the change is propagated to all its subtypes
     Given graql define
       """

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1069,6 +1069,10 @@ Feature: Graql Match Query
     Then session transaction is open: false
     Then the integrity is validated
 
+
+  # TODO: fix - query does not throw exception, but it should
+  @ignore
+  Scenario: an error is thrown when matching an entity type as if it were a relation type
     Then graql match; throws exception
       """
       match ($x) isa person;
@@ -1505,7 +1509,7 @@ Feature: Graql Match Query
     Given graql define
       """
       define
-     unit sub attribute, value string, owns unit, owns ref;
+      unit sub attribute, value string, owns unit, owns ref;
       """
     Given transaction commits
     Given the integrity is validated


### PR DESCRIPTION
## What is the goal of this PR?

Our Graql Define tests were nearly passing in Core and Clients, with only a small handful of failures. So we temporarily marked the failing tests as 'ignored' allowing us to enable the Define tests in CI and guard against regressions.

## What are the changes implemented in this PR?

- Ignore failing Graql Define tests, for now
- Comment out an unimplemented Scenario Outline (it does not sit well with Client Python's `behave` framework)
- Fix a Match test that was vacuous (not actually testing the thing it claimed to)
