### PR TITLE
Add scenario to test overriding roles in plays

### DIFF
--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -522,6 +522,19 @@ Feature: Graql Define Query
     Then the integrity is validated
 
 
+  Scenario: types should be able to define roles they play with an override
+    Then graql define
+      """
+        define
+        locates sub relation, relates located;
+        contractor-locates sub locates, relates contractor-located as located;
+
+        employment sub relation, relates employee, plays locates:located;
+        contractor-employment sub employment, plays contractor-locates:contractor-located as located;
+      """
+    Then the integrity is validated
+
+
   Scenario: a newly defined relation subtype inherits playable roles from its parent type
     Given graql define
       """

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -1584,7 +1584,7 @@ Feature: Graql Define Query
       match $x owns email @key;
       """
     Then answer size is: 0
-    
+
 
   Scenario: defining a rule is idempotent
     Given graql define


### PR DESCRIPTION
## What is the goal of this PR?

We add a test scenario covering the case in which a type plays a role overriding an inherited role.

## What are the changes implemented in this PR?

We added the `types should be able to define roles they play with an override` test scenario to `define.feature`