### PR TITLE
Fix EntityType no-op scenario

### DIFF
--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -954,7 +954,7 @@ Feature: Concept Entity Type
     Then relation(marriage) get role(wife) get players do not contain:
       | person |
 
-  Scenario: Entity types can unset playing role types that they don't actually play, which is a no-op
+  Scenario: Attempting to unset playing a role type that an entity type cannot actually play throws
     When put relation type: marriage
     When relation(marriage) set relates role: husband
     When relation(marriage) set relates role: wife
@@ -962,10 +962,7 @@ Feature: Concept Entity Type
     When entity(person) set plays role: marriage:wife
     Then entity(person) get playing roles do not contain:
       | marriage:husband |
-    Then entity(person) unset plays role: marriage:husband
-    Then entity(person) get playing roles do not contain:
-      | marriage:husband |
-    Then transaction commits
+    Then entity(person) unset plays role: marriage:husband; throws exception
 
   Scenario: Entity types cannot unset playing role types that are currently played by existing instances
     When put relation type: marriage

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -110,7 +110,7 @@ Feature: Graql Undefine Query
       | label:person |
 
 
-  Scenario: undefining sub a supertype that is not a type's direct supertype should still undefine that type
+  Scenario: undefining a type 'sub' an indirect supertype should still remove that type
     Given graql define
       """
       define child sub person;


### PR DESCRIPTION
## What is the goal of this PR?

The behaviour of attempting to undefine a nonexistent graph edge has changed from no-op to throw, necessitating a change in an entitytype scenario testing this behaviour.

## What are the changes implemented in this PR?

- Scenario attempting to unset playing a role type that they do not play has been altered to expect to throw, with name changed to match.
- Indirect sub removal has also been renamed, per a previous request
