### PR TITLE
Split transaction test scenarios that causes wrong exception to be thrown

### DIFF
--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Grakn Labs
+# Copyright (C) 2021 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -580,8 +580,4 @@ Feature: Connection Transaction
     When connection create database: grakn
     Given connection open schema session for database: grakn
     When session opens transaction of type: read
-    Then graql define
-      """
-      define person sub entity;
-      """
     Then transaction commits; throws exception containing "write transactions can be committed"

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -577,6 +577,15 @@ Feature: Connection Transaction
 
 
   Scenario: write in a read transaction throws
+    When connection create database: grakn
+    Given connection open schema session for database: grakn
+    When session opens transaction of type: read
+    Then graql define; throws exception containing "schema writes when session and transaction types do not allow"
+      """
+      define person sub entity;
+      """
+
+  Scenario: commit in a read transaction throws
     When connection create database: grakn
     Given connection open schema session for database: grakn
     When session opens transaction of type: read


### PR DESCRIPTION
## What is the goal of this PR?

Split transaction test scenarios that causes wrong exception to be thrown.

## What are the changes implemented in this PR?

- Split `write in a read transaction throws` into two tests that test schema write violation and commit violation separately.