### PR TITLE
Remove unused integrity validation steps

### DIFF
--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -24,7 +24,7 @@ Feature: Graql Define Query
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -38,7 +38,7 @@ Feature: Graql Define Query
       employment-reference-code sub attribute, value string;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
 
 
@@ -52,7 +52,7 @@ Feature: Graql Define Query
       define dog sub entity;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -69,7 +69,7 @@ Feature: Graql Define Query
       define child sub person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -86,7 +86,7 @@ Feature: Graql Define Query
       """
       define book sub entity, owns pages;
       """
-    Then the integrity is validated
+
 
 
   Scenario: types cannot own entity types
@@ -94,7 +94,7 @@ Feature: Graql Define Query
       """
       define house sub entity, owns person;
       """
-    Then the integrity is validated
+
 
 
   Scenario: types cannot own relation types
@@ -102,7 +102,7 @@ Feature: Graql Define Query
       """
       define company sub entity, owns employment;
       """
-    Then the integrity is validated
+
 
 
   Scenario: when defining that a type plays a non-existent role, an error is thrown
@@ -110,7 +110,7 @@ Feature: Graql Define Query
       """
       define house sub entity, plays constructed:something;
       """
-    Then the integrity is validated
+
 
 
   Scenario: types cannot play entity types
@@ -118,7 +118,7 @@ Feature: Graql Define Query
       """
       define parrot sub entity, plays person;
       """
-    Then the integrity is validated
+
 
 
   Scenario: types can not own entity types as keys
@@ -126,7 +126,7 @@ Feature: Graql Define Query
       """
       define passport sub entity, owns person @key;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a newly defined entity subtype inherits playable roles from its parent type
@@ -135,7 +135,7 @@ Feature: Graql Define Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -156,7 +156,7 @@ Feature: Graql Define Query
       sprinter sub runner;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -176,7 +176,7 @@ Feature: Graql Define Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -197,7 +197,7 @@ Feature: Graql Define Query
       sprinter sub runner;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -217,7 +217,7 @@ Feature: Graql Define Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -238,7 +238,7 @@ Feature: Graql Define Query
       sprinter sub runner;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -261,7 +261,7 @@ Feature: Graql Define Query
       person plays home-ownership:owner;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -280,7 +280,7 @@ Feature: Graql Define Query
       house sub entity, owns price, owns price, owns price;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -299,7 +299,7 @@ Feature: Graql Define Query
       house sub entity, owns address @key, owns address @key, owns address @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -315,7 +315,7 @@ Feature: Graql Define Query
       """
       define flying-spaghetti-monster;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a type cannot directly subtype 'thing' itself
@@ -323,7 +323,7 @@ Feature: Graql Define Query
       """
       define column sub thing;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an entity type can not have a value type defined
@@ -331,7 +331,7 @@ Feature: Graql Define Query
       """
       define cream sub entity, value double;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a type cannot have a 'when' block
@@ -339,7 +339,7 @@ Feature: Graql Define Query
       """
       define gorilla sub entity, when { $x isa gorilla; };
       """
-    Then the integrity is validated
+
 
 
   Scenario: a type cannot have a 'then' block
@@ -347,7 +347,7 @@ Feature: Graql Define Query
       """
       define godzilla sub entity, then { $x isa godzilla; };
       """
-    Then the integrity is validated
+
 
 
   Scenario: defining a thing with 'isa' is not possible in a 'define' query
@@ -355,7 +355,7 @@ Feature: Graql Define Query
       """
       define $p isa person;
       """
-    Then the integrity is validated
+
 
 
   Scenario: adding an attribute instance to a thing is not possible in a 'define' query
@@ -363,7 +363,7 @@ Feature: Graql Define Query
       """
       define $p has name "Loch Ness Monster";
       """
-    Then the integrity is validated
+
 
 
   Scenario: writing a variable in a 'define' is not allowed
@@ -371,7 +371,7 @@ Feature: Graql Define Query
       """
       define $x sub entity;
       """
-    Then the integrity is validated
+
 
 
   ##################
@@ -384,7 +384,7 @@ Feature: Graql Define Query
       define pet-ownership sub relation, relates pet-owner, relates owned-pet;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -401,7 +401,7 @@ Feature: Graql Define Query
       define fun-employment sub employment, relates employee-having-fun as employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -419,7 +419,7 @@ Feature: Graql Define Query
       define useless-relation sub relation;
       """
     Then transaction commits; throws exception
-    Then the integrity is validated
+
 
 
   Scenario: a newly defined relation subtype inherits roles from its supertype
@@ -428,7 +428,7 @@ Feature: Graql Define Query
       define part-time-employment sub employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -451,7 +451,7 @@ Feature: Graql Define Query
       father-sonhood sub parenthood, relates father as parent, relates son as child;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -481,7 +481,7 @@ Feature: Graql Define Query
       father-sonhood sub parenthood, relates father as parent, relates son as child;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -502,7 +502,7 @@ Feature: Graql Define Query
       define part-time-employment sub employment, relates part-timer as employee;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -519,7 +519,7 @@ Feature: Graql Define Query
       define
       close-friendship sub relation, relates close-friend as friend;
       """
-    Then the integrity is validated
+
 
 
   Scenario: types should be able to define roles they play with an override
@@ -532,7 +532,7 @@ Feature: Graql Define Query
         employment sub relation, relates employee, plays locates:located;
         contractor-employment sub employment, plays contractor-locates:contractor-located as located;
       """
-    Then the integrity is validated
+
 
 
   Scenario: already shadowed types should not be overrideable
@@ -547,7 +547,7 @@ Feature: Graql Define Query
         contractor-employment sub employment, plays contractor-locates:contractor-located as located;
         software-contractor-employment sub contractor-employment, plays software-contractor-locates:software-contractor-located as located;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a newly defined relation subtype inherits playable roles from its parent type
@@ -556,7 +556,7 @@ Feature: Graql Define Query
       define contract-employment sub employment, relates contractor as employee;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -577,7 +577,7 @@ Feature: Graql Define Query
       flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -597,7 +597,7 @@ Feature: Graql Define Query
       define contract-employment sub employment, relates contractor as employee;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -618,7 +618,7 @@ Feature: Graql Define Query
       flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -638,7 +638,7 @@ Feature: Graql Define Query
       define contract-employment sub employment, relates contractor as employee;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -659,7 +659,7 @@ Feature: Graql Define Query
       flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -679,7 +679,7 @@ Feature: Graql Define Query
       define connection sub relation, abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -698,7 +698,7 @@ Feature: Graql Define Query
       person plays parenthood:parent, plays parenthood:child;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -717,7 +717,7 @@ Feature: Graql Define Query
       loan sub relation, relates owner;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -739,7 +739,7 @@ Feature: Graql Define Query
       define <label> sub attribute, value <value_type>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -763,7 +763,7 @@ Feature: Graql Define Query
       """
       define colour sub attribute;
       """
-    Then the integrity is validated
+
 
 
   Scenario: defining an attribute type throws if the specified value type is not a recognised value type
@@ -771,7 +771,7 @@ Feature: Graql Define Query
       """
       define colour sub attribute, value rgba;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a new attribute type can be defined as a subtype of an abstract attribute type
@@ -782,7 +782,7 @@ Feature: Graql Define Query
       door-code sub code;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -802,7 +802,7 @@ Feature: Graql Define Query
       door-code sub code;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -818,7 +818,7 @@ Feature: Graql Define Query
       """
       define code-name sub name, value long;
       """
-    Then the integrity is validated
+
 
 
   # TODO: re-enable when fixed (currently gives wrong answer)
@@ -829,7 +829,7 @@ Feature: Graql Define Query
       define response sub attribute, value string, regex "^(yes|no|maybe)$";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -845,7 +845,7 @@ Feature: Graql Define Query
       """
       define name-in-binary sub attribute, value long, regex "^(0|1)+$";
       """
-    Then the integrity is validated
+
 
 
   Scenario: a newly defined attribute subtype inherits playable roles from its parent type
@@ -858,7 +858,7 @@ Feature: Graql Define Query
       grayscale-colour sub colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -882,7 +882,7 @@ Feature: Graql Define Query
       uk-premium-landline-number sub uk-landline-number;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -905,7 +905,7 @@ Feature: Graql Define Query
       grayscale-colour sub colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -928,7 +928,7 @@ Feature: Graql Define Query
       uk-premium-landline-number sub uk-landline-number;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -951,7 +951,7 @@ Feature: Graql Define Query
       grayscale-colour sub colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -974,7 +974,7 @@ Feature: Graql Define Query
       very-dark-red-colour sub dark-red-colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -996,7 +996,7 @@ Feature: Graql Define Query
       person owns <label>;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1031,7 +1031,7 @@ Feature: Graql Define Query
       define animal sub entity, abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1050,7 +1050,7 @@ Feature: Graql Define Query
       horse sub animal;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1070,7 +1070,7 @@ Feature: Graql Define Query
       fish sub animal, abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1090,7 +1090,7 @@ Feature: Graql Define Query
       grakn-exception sub exception, abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1107,7 +1107,7 @@ Feature: Graql Define Query
       define membership sub relation, abstract, relates member;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1126,7 +1126,7 @@ Feature: Graql Define Query
       gym-membership sub membership, relates gym-with-members, relates gym-member as member;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1146,7 +1146,7 @@ Feature: Graql Define Query
       tool-requirement sub requirement, abstract, relates required-tool as prerequisite;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1166,7 +1166,7 @@ Feature: Graql Define Query
       tech-requirement sub requirement, abstract, relates required-tech as prerequisite;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1183,7 +1183,7 @@ Feature: Graql Define Query
       define number-of-limbs sub attribute, abstract, value long;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1202,7 +1202,7 @@ Feature: Graql Define Query
       number-of-legs sub number-of-limbs;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1222,7 +1222,7 @@ Feature: Graql Define Query
       number-of-artificial-limbs sub number-of-limbs, abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1256,7 +1256,7 @@ Feature: Graql Define Query
     Then uniquely identify answer concepts
       | name        | location            |
       | label:name  | label:location-name |
-    Then the integrity is validated
+
 
 
   Scenario: repeating the term 'abstract' when defining a type causes an error to be thrown
@@ -1264,7 +1264,7 @@ Feature: Graql Define Query
       """
       define animal sub entity, abstract, abstract, abstract;
       """
-    Then the integrity is validated
+
 
 
   ###################
@@ -1280,7 +1280,7 @@ Feature: Graql Define Query
       person sub entity, owns name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1296,7 +1296,7 @@ Feature: Graql Define Query
       person sub relation, relates body-part;
       arm sub entity, plays person:body-part;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a relation type cannot be changed into an attribute type
@@ -1304,7 +1304,7 @@ Feature: Graql Define Query
       """
       define employment sub attribute, value string;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an attribute type cannot be changed into an entity type
@@ -1312,7 +1312,7 @@ Feature: Graql Define Query
       """
       define name sub entity;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a new attribute ownership can be defined on an existing type
@@ -1321,7 +1321,7 @@ Feature: Graql Define Query
       define employment owns name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1339,7 +1339,7 @@ Feature: Graql Define Query
       define employment plays employment:employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1359,7 +1359,7 @@ Feature: Graql Define Query
       product sub entity, owns name, owns barcode;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1370,7 +1370,7 @@ Feature: Graql Define Query
       $y isa product, has name "Ham", has barcode "10011";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1380,7 +1380,7 @@ Feature: Graql Define Query
       product owns barcode @key;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1399,7 +1399,7 @@ Feature: Graql Define Query
       product sub entity, owns name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1410,7 +1410,7 @@ Feature: Graql Define Query
       $y isa product, has name "Ham";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1419,7 +1419,7 @@ Feature: Graql Define Query
       define
       product owns barcode @key;
       """
-    Then the integrity is validated
+
 
 
   Scenario: defining a key on a type throws if there is a key collision between two existing instances
@@ -1430,7 +1430,7 @@ Feature: Graql Define Query
       product sub entity, owns name, owns barcode;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1441,7 +1441,7 @@ Feature: Graql Define Query
       $y isa product, has name "Ham", has barcode "10000";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1450,7 +1450,7 @@ Feature: Graql Define Query
       define
       product owns barcode @key;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a new role can be defined on an existing relation type
@@ -1461,7 +1461,7 @@ Feature: Graql Define Query
       employment relates employer;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1482,7 +1482,7 @@ Feature: Graql Define Query
       $x isa person, has name "Alice", has email "alice@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1491,7 +1491,7 @@ Feature: Graql Define Query
       define name regex "^A.*$";
       """
     Then transaction commits
-    Then the integrity is validated
+
     Then session opens transaction of type: read
     Then get answers of graql match
       """
@@ -1512,7 +1512,7 @@ Feature: Graql Define Query
       $x isa person, has name "Maria", has email "maria@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1520,7 +1520,7 @@ Feature: Graql Define Query
       """
       define name regex "^A.*$";
       """
-    Then the integrity is validated
+
 
 
   Scenario: a regex constraint can not be added to an existing attribute type whose value type isn't 'string'
@@ -1529,13 +1529,13 @@ Feature: Graql Define Query
       define house-number sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Then graql define; throws exception
       """
       define house-number regex "^A.*$";
       """
-    Then the integrity is validated
+
 
 
   Scenario: related roles cannot be added to existing entity types
@@ -1543,7 +1543,7 @@ Feature: Graql Define Query
       """
       define person relates employee;
       """
-    Then the integrity is validated
+
 
 
   Scenario: related roles cannot be added to existing attribute types
@@ -1551,7 +1551,7 @@ Feature: Graql Define Query
       """
       define name relates employee;
       """
-    Then the integrity is validated
+
 
 
   Scenario: the value type of an existing attribute type is not modifiable
@@ -1559,7 +1559,7 @@ Feature: Graql Define Query
       """
       define name value long;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an attribute ownership can be converted to a key ownership
@@ -1568,7 +1568,7 @@ Feature: Graql Define Query
       define person owns name @key;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1585,7 +1585,7 @@ Feature: Graql Define Query
       define person owns email;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1614,7 +1614,7 @@ Feature: Graql Define Query
         $p has nickname "Bob";
       };
       """
-    Given the integrity is validated
+
     Then graql define
       """
       define
@@ -1625,7 +1625,7 @@ Feature: Graql Define Query
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: redefining an existing rule updates its definition
@@ -1641,7 +1641,7 @@ Feature: Graql Define Query
       define person abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1658,7 +1658,7 @@ Feature: Graql Define Query
       define employment abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1675,7 +1675,7 @@ Feature: Graql Define Query
       define name abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1696,7 +1696,7 @@ Feature: Graql Define Query
       $x isa person, has name "Jeremy", has email "jeremy@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1704,7 +1704,7 @@ Feature: Graql Define Query
       """
       define person abstract;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an existing relation type cannot be converted to abstract if it has existing instances
@@ -1718,7 +1718,7 @@ Feature: Graql Define Query
       $r (employee: $x) isa employment, has employment-reference-code "J123123";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1738,7 +1738,7 @@ Feature: Graql Define Query
       $x isa person, has name "Jeremy", has email "jeremy@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1746,7 +1746,7 @@ Feature: Graql Define Query
       """
       define name abstract;
       """
-    Then the integrity is validated
+
 
 
   Scenario: changing a concrete type to abstract throws on commit if it has a concrete supertype
@@ -1771,7 +1771,7 @@ Feature: Graql Define Query
       genius sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql define
       """
@@ -1779,7 +1779,7 @@ Feature: Graql Define Query
       genius sub apple-product;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1803,7 +1803,7 @@ Feature: Graql Define Query
       shoe sub entity, owns shoe-size;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1812,7 +1812,7 @@ Feature: Graql Define Query
       insert $s isa shoe, has shoe-size 9;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1823,7 +1823,7 @@ Feature: Graql Define Query
       shoe-size sub size;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1845,7 +1845,7 @@ Feature: Graql Define Query
       child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql define
       """
@@ -1853,7 +1853,7 @@ Feature: Graql Define Query
       person sub organism;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1874,7 +1874,7 @@ Feature: Graql Define Query
       pigeon sub bird;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1883,7 +1883,7 @@ Feature: Graql Define Query
       insert $p isa pigeon;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1894,7 +1894,7 @@ Feature: Graql Define Query
       pigeon sub animal;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1914,7 +1914,7 @@ Feature: Graql Define Query
       flying sub relation, relates flier;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1923,7 +1923,7 @@ Feature: Graql Define Query
       insert $p isa pigeon;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1934,7 +1934,7 @@ Feature: Graql Define Query
       pigeon sub animal;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1954,7 +1954,7 @@ Feature: Graql Define Query
       pigeon sub bird;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1963,7 +1963,7 @@ Feature: Graql Define Query
       insert $p isa pigeon;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1974,7 +1974,7 @@ Feature: Graql Define Query
       pigeon sub animal;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2020,7 +2020,7 @@ Feature: Graql Define Query
       person sub entity, plays employment:employer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2042,7 +2042,7 @@ Feature: Graql Define Query
        person sub entity, owns phone-number;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2064,7 +2064,7 @@ Feature: Graql Define Query
       person sub entity, owns phone-number @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2084,7 +2084,7 @@ Feature: Graql Define Query
       employment sub relation, relates employer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2114,7 +2114,7 @@ Feature: Graql Define Query
       """
       match $x type dog;
       """
-    Then the integrity is validated
+
 
 
   ########################
@@ -2126,7 +2126,7 @@ Feature: Graql Define Query
       """
       define dog sub dog;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a cyclic type hierarchy is not allowed
@@ -2137,7 +2137,7 @@ Feature: Graql Define Query
       green-giant sub giant;
       person sub green-giant;
       """
-    Then the integrity is validated
+
 
   Scenario: two attribute types can own each other in a cycle
     Given graql define
@@ -2198,7 +2198,7 @@ Feature: Graql Define Query
       recursive-function sub relation, relates function, plays recursive-function:function;
       """
     Then transaction commits
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2215,7 +2215,7 @@ Feature: Graql Define Query
       define number-of-letters sub attribute, value long, owns number-of-letters;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2233,7 +2233,7 @@ Feature: Graql Define Query
       apple sub relation, abstract, relates role1, plays big-apple:role2;
       big-apple sub apple, plays apple:role1, relates role2;
       """
-    Then the integrity is validated
+
 
 
   Scenario: relation types that play roles in their transitive subtypes can be reliably defined
@@ -2287,4 +2287,4 @@ Feature: Graql Define Query
       huge-pineapple sub big-pineapple, relates tree, relates grows-from;
       """
     Then transaction commits
-    Then the integrity is validated
+

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -24,7 +24,7 @@ Feature: Graql Delete Query
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -38,7 +38,7 @@ Feature: Graql Delete Query
       ref sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -59,7 +59,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
@@ -74,7 +74,7 @@ Feature: Graql Delete Query
         $x isa thing; $r isa thing; $n isa thing;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -109,7 +109,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
@@ -122,7 +122,7 @@ Feature: Graql Delete Query
         $r isa thing;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -144,7 +144,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
@@ -157,7 +157,7 @@ Feature: Graql Delete Query
         $r isa entity;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -179,7 +179,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | ket:ref:0 | value:name:John |
@@ -192,7 +192,7 @@ Feature: Graql Delete Query
         $r isa relation;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -208,7 +208,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | n               |
       | value:name:John |
@@ -221,7 +221,7 @@ Feature: Graql Delete Query
         $r isa attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -241,7 +241,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
       | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
@@ -254,7 +254,7 @@ Feature: Graql Delete Query
         $r isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -273,7 +273,7 @@ Feature: Graql Delete Query
       $b isa person, has name "Barbara";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | a              | b                |
       | key:name:Alice | key:name:Barbara |
@@ -286,7 +286,7 @@ Feature: Graql Delete Query
       $p isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -303,7 +303,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -313,7 +313,7 @@ Feature: Graql Delete Query
       delete
         $r isa person;
       """
-    Then the integrity is validated
+
 
 
   Scenario: deleting an instance using a non-existing type label throws
@@ -323,7 +323,7 @@ Feature: Graql Delete Query
       $n "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -332,7 +332,7 @@ Feature: Graql Delete Query
       delete
         $r isa heffalump;
       """
-    Then the integrity is validated
+
 
 
   Scenario: deleting a relation instance using a too-specific (downcasting) type throws
@@ -345,7 +345,7 @@ Feature: Graql Delete Query
       special-friendship sub friendship;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -357,7 +357,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -366,7 +366,7 @@ Feature: Graql Delete Query
       delete
         $r isa special-friendship;
       """
-    Then the integrity is validated
+
 
 
   ###############
@@ -384,7 +384,7 @@ Feature: Graql Delete Query
          has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | z               | r         |
       | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
@@ -400,7 +400,7 @@ Feature: Graql Delete Query
         $r (friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -423,7 +423,7 @@ Feature: Graql Delete Query
          has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | z               | r         |
       | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
@@ -439,7 +439,7 @@ Feature: Graql Delete Query
         $r (role: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -463,7 +463,7 @@ Feature: Graql Delete Query
       person plays special-friendship:special-friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -477,7 +477,7 @@ Feature: Graql Delete Query
          has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | z               | r         |
       | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
@@ -493,7 +493,7 @@ Feature: Graql Delete Query
         $r (friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -516,11 +516,11 @@ Feature: Graql Delete Query
       $r2 (friend: $x, friend: $z) isa friendship, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | z               | r         | r2        |
       | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:1 | key:ref:2 |
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql delete
       """
@@ -529,9 +529,9 @@ Feature: Graql Delete Query
       delete
         $x isa person;
       """
-    Then the integrity is validated
+
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -560,7 +560,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -573,7 +573,7 @@ Feature: Graql Delete Query
         $r (friend: $x, friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -593,7 +593,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $x, friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -606,7 +606,7 @@ Feature: Graql Delete Query
         $r (friend: $x, friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -627,7 +627,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $x, friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -642,7 +642,7 @@ Feature: Graql Delete Query
         $r (friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -663,7 +663,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -677,7 +677,7 @@ Feature: Graql Delete Query
         $r (friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -699,7 +699,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y, friend: $z) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | z               | r         |
       | key:name:Alex | key:name:Bob | key:name:Carrie | key:ref:0 |
@@ -716,7 +716,7 @@ Feature: Graql Delete Query
         $r (friend: $y);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -736,7 +736,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql delete; throws exception
       """
@@ -747,7 +747,7 @@ Feature: Graql Delete Query
       delete
         $r (friend: $x, friend: $x);
       """
-    Then the integrity is validated
+
 
 
   Scenario: when all instances that play roles in a relation are deleted, the relation instance gets cleaned up
@@ -759,7 +759,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -774,7 +774,7 @@ Feature: Graql Delete Query
         $y isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -792,7 +792,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y            | r         |
       | key:name:Alex | key:name:Bob | key:ref:0 |
@@ -808,7 +808,7 @@ Feature: Graql Delete Query
         $r (role: $y);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -828,7 +828,7 @@ Feature: Graql Delete Query
         relates special-friend as friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -840,7 +840,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -851,7 +851,7 @@ Feature: Graql Delete Query
       delete
         $r (special-friend: $x);
       """
-    Then the integrity is validated
+
 
 
 #  Even when a $role variable matches multiple roles (will always match 'role' unless constrained)
@@ -877,7 +877,7 @@ Feature: Graql Delete Query
       person plays ship-crew:captain, plays ship-crew:navigator, plays ship-crew:chef;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -890,7 +890,7 @@ Feature: Graql Delete Query
       $r (captain: $x, navigator: $y, chef: $z) isa ship-crew;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -899,7 +899,7 @@ Feature: Graql Delete Query
       delete
         $r ($role1: $x);
       """
-    Then the integrity is validated
+
 
 
 #  Even when a $role variable matches multiple roles (will always match 'role' unless constrained)
@@ -926,7 +926,7 @@ Feature: Graql Delete Query
       person plays ship-crew:captain, plays ship-crew:navigator, plays ship-crew:chef;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -938,7 +938,7 @@ Feature: Graql Delete Query
       $r (captain: $x, chef: $y, chef: $y) isa ship-crew, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -955,7 +955,7 @@ Feature: Graql Delete Query
         $r ($role1: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -979,7 +979,7 @@ Feature: Graql Delete Query
       person owns age;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -989,7 +989,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Anna", has age 18;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1006,7 +1006,7 @@ Feature: Graql Delete Query
         $x isa attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1026,7 +1026,7 @@ Feature: Graql Delete Query
       person sub entity, owns lastname;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1041,7 +1041,7 @@ Feature: Graql Delete Query
         has name "John";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x             | y             |
       | key:name:Alex | key:name:John |
@@ -1055,7 +1055,7 @@ Feature: Graql Delete Query
         $x has lastname $n;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1093,7 +1093,7 @@ Feature: Graql Delete Query
       person owns postcode;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1103,7 +1103,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Sherlock", has postcode "W1U8ED";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x                 |
       | key:name:Sherlock |
@@ -1125,7 +1125,7 @@ Feature: Graql Delete Query
         $x has attribute $a;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1148,7 +1148,7 @@ Feature: Graql Delete Query
       person owns postcode;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1158,7 +1158,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Sherlock", has postcode "W1U8ED";
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1175,7 +1175,7 @@ Feature: Graql Delete Query
         $x has address $a;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1196,7 +1196,7 @@ Feature: Graql Delete Query
       person owns postcode;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1206,7 +1206,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Sherlock", has postcode "W1U8ED";
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -1215,7 +1215,7 @@ Feature: Graql Delete Query
       delete
         $x has thing $a;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an attribute can be specified by direct type when deleting an ownership of it
@@ -1225,7 +1225,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Watson";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Then uniquely identify answer concepts
       | x               |
       | key:name:Watson |
@@ -1238,7 +1238,7 @@ Feature: Graql Delete Query
         $x isa! person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1254,7 +1254,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Watson";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -1263,7 +1263,7 @@ Feature: Graql Delete Query
       delete
         $x isa! entity;
       """
-    Then the integrity is validated
+
 
 
   Scenario: deleting the owner of an attribute also deletes the attribute ownership
@@ -1277,7 +1277,7 @@ Feature: Graql Delete Query
       friendship owns duration;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1289,7 +1289,7 @@ Feature: Graql Delete Query
       $r (friend: $x, friend: $y) isa friendship, has ref 0, has duration 1000;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When get answers of graql match
       """
@@ -1306,7 +1306,7 @@ Feature: Graql Delete Query
         $r isa relation;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1326,7 +1326,7 @@ Feature: Graql Delete Query
       friendship owns duration;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1337,7 +1337,7 @@ Feature: Graql Delete Query
       $r (friend: $x) isa friendship, has ref 0, has duration 1000;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1354,7 +1354,7 @@ Feature: Graql Delete Query
         $r (friend: $x);
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1376,7 +1376,7 @@ Feature: Graql Delete Query
       delete
         $x has diameter $val;
       """
-    Then the integrity is validated
+
 
 
   ####################
@@ -1394,7 +1394,7 @@ Feature: Graql Delete Query
       person sub entity, owns lastname;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1412,7 +1412,7 @@ Feature: Graql Delete Query
       $reflexive (friend: $x, friend: $x) isa friendship, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql delete
       """
@@ -1427,7 +1427,7 @@ Feature: Graql Delete Query
         $f1 isa friendship;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1466,7 +1466,7 @@ Feature: Graql Delete Query
       person sub entity, owns lastname;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1484,7 +1484,7 @@ Feature: Graql Delete Query
       $reflexive (friend: $x, friend: $x) isa friendship, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql delete
       """
@@ -1500,7 +1500,7 @@ Feature: Graql Delete Query
         $f1 (friend: $x, friend: $y) isa friendship, has ref $r2;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1518,7 +1518,7 @@ Feature: Graql Delete Query
       """
       match $x isa person; delete $n isa name;
       """
-    Then the integrity is validated
+
 
 
   Scenario: deleting a has ownership @key throws on commit
@@ -1528,7 +1528,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Alex";
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Then graql delete; throws exception
       """
@@ -1538,7 +1538,7 @@ Feature: Graql Delete Query
       delete
         $x has name $n;
       """
-    Then the integrity is validated
+
 
 
   @ignore
@@ -1550,7 +1550,7 @@ Feature: Graql Delete Query
       $x isa person, has name "Tatyana";
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1566,7 +1566,7 @@ Feature: Graql Delete Query
       delete
         $x isa attribute;
       """
-    Then the integrity is validated
+
 
 
   Scenario: deleting a type throws an error
@@ -1577,4 +1577,4 @@ Feature: Graql Delete Query
       delete
         $x isa thing;
       """
-    Then the integrity is validated
+

--- a/graql/language/get.feature
+++ b/graql/language/get.feature
@@ -24,7 +24,7 @@ Feature: Graql Get Clause
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -50,7 +50,7 @@ Feature: Graql Get Clause
       ref sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -69,7 +69,7 @@ Feature: Graql Get Clause
       $z isa person, has name $x, has age $y, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -87,7 +87,7 @@ Feature: Graql Get Clause
       """
       match $x isa person; get $y;
       """
-    Then the integrity is validated
+
 
 
   ########
@@ -104,7 +104,7 @@ Feature: Graql Get Clause
       <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -117,7 +117,7 @@ Feature: Graql Get Clause
       $d <val4> isa <attr>, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -149,7 +149,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -185,7 +185,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -210,7 +210,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -235,7 +235,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -259,7 +259,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -284,7 +284,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -305,7 +305,7 @@ Feature: Graql Get Clause
       $d isa person, has name "Brenda", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -327,7 +327,7 @@ Feature: Graql Get Clause
       $e "secret agent" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then get answers of graql match
       """
@@ -354,7 +354,7 @@ Feature: Graql Get Clause
       $e isa person, has age 2, has ref 4;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -387,7 +387,7 @@ Feature: Graql Get Clause
       $b isa person, has age 6, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
@@ -413,7 +413,7 @@ Feature: Graql Get Clause
       $f (friend: $p1, friend: $p2) isa friendship, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -471,7 +471,7 @@ Feature: Graql Get Clause
       person owns <attr>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -483,7 +483,7 @@ Feature: Graql Get Clause
       $p3 isa person, has <attr> <val3>, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -517,7 +517,7 @@ Feature: Graql Get Clause
       person owns weight;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -529,7 +529,7 @@ Feature: Graql Get Clause
       $p3 isa person, has weight 24.8, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -549,7 +549,7 @@ Feature: Graql Get Clause
       $p3 isa person, has name "Miles", has age 15, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -574,7 +574,7 @@ Feature: Graql Get Clause
       $p3 isa person, has age <val3>, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -599,7 +599,7 @@ Feature: Graql Get Clause
       $p4 isa person, has age 35, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -620,7 +620,7 @@ Feature: Graql Get Clause
       person owns income;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answer of graql match aggregate
       """
@@ -662,14 +662,14 @@ Feature: Graql Get Clause
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
       match $x isa person;
       min $x;
       """
-    Then the integrity is validated
+
 
 
   Scenario Outline: an error is thrown when getting the '<agg_type>' of attributes that have the inapplicable type, '<type>'
@@ -683,7 +683,7 @@ Feature: Graql Get Clause
       person owns <attr>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -693,14 +693,14 @@ Feature: Graql Get Clause
       $x isa person, has ref 0, has <attr> <value>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
       match $x isa person, has <attr> $y;
       <agg_type> $y;
       """
-    Then the integrity is validated
+
 
     Examples:
       | attr       | type     | value      | agg_type |
@@ -732,14 +732,14 @@ Feature: Graql Get Clause
       $y isa person, has name "Gloria", has age 28, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
       match $x isa person, has attribute $y;
       sum $y;
       """
-    Then the integrity is validated
+
 
 
   Scenario: when taking the sum of an empty set, even if any matches would definitely be strings, no error is thrown and an empty answer is returned
@@ -766,7 +766,7 @@ Feature: Graql Get Clause
       $f (friend: $p1, friend: $p2, friend: $p3, friend: $p4) isa friendship, has ref 4;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -816,7 +816,7 @@ Feature: Graql Get Clause
       $f (friend: $p1, friend: $p2) isa friendship, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
@@ -824,7 +824,7 @@ Feature: Graql Get Clause
       get $x;
       group $y;
       """
-    Then the integrity is validated
+
 
 
   ###################
@@ -842,7 +842,7 @@ Feature: Graql Get Clause
       $f (friend: $p1, friend: $p2, friend: $p3, friend: $p4) isa friendship, has ref 4;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -874,7 +874,7 @@ Feature: Graql Get Clause
       $e2 (employer: $c2, employee: $p3) isa employment, has ref 6;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -926,7 +926,7 @@ Feature: Graql Get Clause
       $e2 (employer: $c2, employee: $p4) isa employment, has ref 7;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match group aggregate
       """

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -24,7 +24,7 @@ Feature: Graql Insert Query
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -55,7 +55,7 @@ Feature: Graql Insert Query
         value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -71,7 +71,7 @@ Feature: Graql Insert Query
       insert $x isa person, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -90,7 +90,7 @@ Feature: Graql Insert Query
       $y isa person, has ref 1;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -111,7 +111,7 @@ Feature: Graql Insert Query
       $x isa person, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -147,7 +147,7 @@ Feature: Graql Insert Query
       dog sub entity, owns breed;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -161,7 +161,7 @@ Feature: Graql Insert Query
       insert $x isa dog, has breed "Labrador";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -173,7 +173,7 @@ Feature: Graql Insert Query
       insert $x isa dog, has breed "Labrador";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -185,7 +185,7 @@ Feature: Graql Insert Query
       insert $x isa dog, has breed "Labrador";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -199,7 +199,7 @@ Feature: Graql Insert Query
       """
       insert $x isa! person, has name "Harry", has ref 0;
       """
-    Then the integrity is validated
+
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
@@ -216,7 +216,7 @@ Feature: Graql Insert Query
       electronics-factory sub factory;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -224,7 +224,7 @@ Feature: Graql Insert Query
       """
       insert $x isa factory;
       """
-    Then the integrity is validated
+
 
 
   Scenario: attempting to insert an instance of type 'thing' throws an error
@@ -232,7 +232,7 @@ Feature: Graql Insert Query
       """
       insert $x isa thing;
       """
-    Then the integrity is validated
+
 
 
   #######################
@@ -250,7 +250,7 @@ Feature: Graql Insert Query
       insert $x isa person, has name "Wilhelmina", has age 25, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -270,7 +270,7 @@ Feature: Graql Insert Query
       insert $name "John" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -285,14 +285,14 @@ Feature: Graql Insert Query
       insert $name "Kyle" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Given graql insert
       """
       insert $x isa person, has name "Kyle", has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -311,7 +311,7 @@ Feature: Graql Insert Query
       $p2 isa person, has name "Jill", has age 10, has ref 1;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -337,7 +337,7 @@ Feature: Graql Insert Query
       dog sub entity, owns name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -351,7 +351,7 @@ Feature: Graql Insert Query
       $p5 isa dog, has name "Jacob";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -368,7 +368,7 @@ Feature: Graql Insert Query
         $p2 isa dog, has name $name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -388,7 +388,7 @@ Feature: Graql Insert Query
       person owns <attr>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -400,7 +400,7 @@ Feature: Graql Insert Query
       $p isa person, has name "Imogen", has ref 2, has <attr> <val1>, has <attr> <val2>;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -426,7 +426,7 @@ Feature: Graql Insert Query
       insert
       $x isa company, has ref 0, has age 10;
       """
-    Then the integrity is validated
+
 
 
   ########################################
@@ -440,7 +440,7 @@ Feature: Graql Insert Query
       $p isa person, has name "Peter Parker", has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -455,7 +455,7 @@ Feature: Graql Insert Query
         $p has name "Spiderman";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -473,7 +473,7 @@ Feature: Graql Insert Query
       $p isa person, has name "Peter Parker", has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -488,7 +488,7 @@ Feature: Graql Insert Query
         $p isa person, has name "Spiderman";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -510,7 +510,7 @@ Feature: Graql Insert Query
       hex-value sub attribute, value string;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -520,7 +520,7 @@ Feature: Graql Insert Query
       $c "red" isa colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -535,7 +535,7 @@ Feature: Graql Insert Query
         $c has hex-value "#FF0000";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -557,7 +557,7 @@ Feature: Graql Insert Query
       hex-value sub attribute, value string;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -567,7 +567,7 @@ Feature: Graql Insert Query
       $c "red" isa colour;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -582,7 +582,7 @@ Feature: Graql Insert Query
         $c isa colour, has hex-value "#FF0000";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -610,7 +610,7 @@ Feature: Graql Insert Query
       tenure-days sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -622,7 +622,7 @@ Feature: Graql Insert Query
       $r (resident: $p, place: $addr) isa residence, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -637,7 +637,7 @@ Feature: Graql Insert Query
         $r has tenure-days 365;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -664,7 +664,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -673,7 +673,7 @@ Feature: Graql Insert Query
       insert $p isa person, has name "Lucy", has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -690,7 +690,7 @@ Feature: Graql Insert Query
         $p has age 32;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -713,7 +713,7 @@ Feature: Graql Insert Query
       $r (employee: $p) isa employment, has ref 1;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -741,7 +741,7 @@ Feature: Graql Insert Query
       is-permanent sub attribute, value boolean;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -754,7 +754,7 @@ Feature: Graql Insert Query
       $addr "742 Evergreen Terrace" isa address;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -775,7 +775,7 @@ Feature: Graql Insert Query
       $r (employer: $c, employee: $p1, employee: $p2) isa employment, has ref 3;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -803,7 +803,7 @@ Feature: Graql Insert Query
       insert $p isa person, has ref 0; $r (employee: $p) isa employment, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -814,7 +814,7 @@ Feature: Graql Insert Query
         $c isa company, has ref 2;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -835,7 +835,7 @@ Feature: Graql Insert Query
       $c isa company, has name "The Boring Company", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -846,7 +846,7 @@ Feature: Graql Insert Query
         $r (employer: $c) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -864,7 +864,7 @@ Feature: Graql Insert Query
       insert $p isa person, has ref 0; $r (employee: $p) isa employment, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -875,7 +875,7 @@ Feature: Graql Insert Query
         $r (employee: $p) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -893,7 +893,7 @@ Feature: Graql Insert Query
       $r (employer: $p) isa employment, has ref 0;
       $p isa person, has ref 1;
       """
-    Then the integrity is validated
+
 
 
   Scenario: parent types are not necessarily allowed to play the roles that their children play
@@ -909,7 +909,7 @@ Feature: Graql Insert Query
       person plays sphinx-production:builder;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -920,7 +920,7 @@ Feature: Graql Insert Query
       $x isa animal;
       $y isa person, has ref 0;
       """
-    Then the integrity is validated
+
 
 
   Scenario: when inserting a relation with no role players, an error is thrown
@@ -929,7 +929,7 @@ Feature: Graql Insert Query
       insert
       $x isa employment, has ref 0;
       """
-    Then the integrity is validated
+
 
 
   Scenario: when inserting a relation with an unbound variable as a roleplayer, an error is thrown
@@ -939,7 +939,7 @@ Feature: Graql Insert Query
       $r (employee: $x, employer: $y) isa employment, has ref 0;
       $y isa company, has name "Sports Direct", has ref 1;
       """
-    Then the integrity is validated
+
 
   #TODO: Reenable when rules actually do something
   @ignore
@@ -960,7 +960,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -969,7 +969,7 @@ Feature: Graql Insert Query
       insert $p isa person, has name "Jennifer", has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -983,7 +983,7 @@ Feature: Graql Insert Query
         $r (member: $p) isa gym-membership;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1012,7 +1012,7 @@ Feature: Graql Insert Query
       define <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1026,7 +1026,7 @@ Feature: Graql Insert Query
       insert $x <value> isa <attr>, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1059,7 +1059,7 @@ Feature: Graql Insert Query
         regex "\d{2}\.[true][false]";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1069,7 +1069,7 @@ Feature: Graql Insert Query
         $x isa person, has value $a, has ref 0;
         $a "10.maybe";
       """
-    Then the integrity is validated
+
 
 
   Scenario: inserting two attributes with the same type and value creates only one concept
@@ -1080,7 +1080,7 @@ Feature: Graql Insert Query
       $y 2 isa age;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1101,7 +1101,7 @@ Feature: Graql Insert Query
       length sub attribute, value double;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1112,7 +1112,7 @@ Feature: Graql Insert Query
       $y 2 isa length;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1134,7 +1134,7 @@ Feature: Graql Insert Query
       length sub attribute, value double;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1144,7 +1144,7 @@ Feature: Graql Insert Query
       $x 2 isa length;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -1152,7 +1152,7 @@ Feature: Graql Insert Query
       $y 2 isa length;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1174,7 +1174,7 @@ Feature: Graql Insert Query
       length sub attribute, value double;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1185,7 +1185,7 @@ Feature: Graql Insert Query
       $y 2.0 isa length;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1203,7 +1203,7 @@ Feature: Graql Insert Query
       define <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1215,7 +1215,7 @@ Feature: Graql Insert Query
       | x         |
       | key:ref:0 |
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1248,7 +1248,7 @@ Feature: Graql Insert Query
       define <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1256,7 +1256,7 @@ Feature: Graql Insert Query
       """
       insert $x <value> isa <attr>, has ref 0;
       """
-    Then the integrity is validated
+
 
     Examples:
       | type     | attr       | value        |
@@ -1296,7 +1296,7 @@ Feature: Graql Insert Query
     Then uniquely identify answer concepts
       | x            |
       | value:age:10 |
-    Then the integrity is validated
+
 
 
   Scenario: inserting an attribute with no value throws an error
@@ -1304,7 +1304,7 @@ Feature: Graql Insert Query
       """
       insert $x isa age;
       """
-    Then the integrity is validated
+
 
 
   Scenario: inserting an attribute value with no type throws an error
@@ -1312,7 +1312,7 @@ Feature: Graql Insert Query
       """
       insert $x 18;
       """
-    Then the integrity is validated
+
 
 
   Scenario: inserting an attribute with a predicate throws an error
@@ -1320,7 +1320,7 @@ Feature: Graql Insert Query
       """
       insert $x > 18 isa age;
       """
-    Then the integrity is validated
+
 
 
   ########
@@ -1333,7 +1333,7 @@ Feature: Graql Insert Query
       insert $x isa person, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1350,7 +1350,7 @@ Feature: Graql Insert Query
       insert $x isa person;
       """
     Then transaction commits; throws exception
-    Then the integrity is validated
+
 
 
   Scenario: inserting two distinct values of the same key on a thing throws an error
@@ -1358,7 +1358,7 @@ Feature: Graql Insert Query
       """
       insert $x isa person, has ref 0, has ref 1;
       """
-    Then the integrity is validated
+
 
 
   Scenario: instances of a key must be unique among all instances of a type
@@ -1368,7 +1368,7 @@ Feature: Graql Insert Query
       $x isa person, has ref 0;
       $y isa person, has ref 0;
       """
-    Then the integrity is validated
+
 
 
   Scenario: an error is thrown when inserting a second key on an attribute that already has one
@@ -1381,7 +1381,7 @@ Feature: Graql Insert Query
       name owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1390,13 +1390,13 @@ Feature: Graql Insert Query
       insert $a "john" isa name, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql insert; throws exception
       """
       insert $a "john" isa name, has ref 1;
       """
-    Then the integrity is validated
+
 
 
   ###########################
@@ -1410,7 +1410,7 @@ Feature: Graql Insert Query
       $x isa person, has name "Bruce Wayne", has ref 0;
       $z isa company, has name "Wayne Enterprises", has ref 0;
       """
-    Then the integrity is validated
+
     Then uniquely identify answer concepts
       | x         | z         |
       | key:ref:0 | key:ref:0 |
@@ -1424,7 +1424,7 @@ Feature: Graql Insert Query
       insert
         $x isa $type, has name "Microsoft", has ref 0;
       """
-    Then the integrity is validated
+
 
   ################
   # MATCH-INSERT #
@@ -1441,7 +1441,7 @@ Feature: Graql Insert Query
       is-cool sub attribute, value boolean;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1452,7 +1452,7 @@ Feature: Graql Insert Query
       $y isa language, has name "Danish", has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert
       """
@@ -1462,7 +1462,7 @@ Feature: Graql Insert Query
         $x has is-cool true;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1481,7 +1481,7 @@ Feature: Graql Insert Query
       $z isa person, has name "Tarja", has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql insert
       """
@@ -1491,7 +1491,7 @@ Feature: Graql Insert Query
       insert
         (employer: $x, employee: $y) isa employment, has ref 10;
       """
-    Then the integrity is validated
+
     # Should only contain variables mentioned in the insert (so excludes '$z')
     Then uniquely identify answer concepts
       | x         | y         |
@@ -1509,7 +1509,7 @@ Feature: Graql Insert Query
       person owns height;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1521,7 +1521,7 @@ Feature: Graql Insert Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given graql insert
       """
@@ -1531,7 +1531,7 @@ Feature: Graql Insert Query
         $x has height 16;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1555,7 +1555,7 @@ Feature: Graql Insert Query
       person plays season-ticket-ownership:holder;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1572,7 +1572,7 @@ Feature: Graql Insert Query
         $r (holder: $p) isa season-ticket-ownership;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1593,7 +1593,7 @@ Feature: Graql Insert Query
       | x         | y         | z         |
       | key:ref:0 | key:ref:1 | key:ref:2 |
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Given get answers of graql match
       """
@@ -1612,7 +1612,7 @@ Feature: Graql Insert Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1641,7 +1641,7 @@ Feature: Graql Insert Query
       | x         | y         | z         | c         | xr        | yr        | zr        |
       | key:ref:0 | key:ref:1 | key:ref:2 | key:ref:3 | key:ref:4 | key:ref:5 | key:ref:6 |
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -1660,7 +1660,7 @@ Feature: Graql Insert Query
         $x isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1685,7 +1685,7 @@ Feature: Graql Insert Query
       | x              | y                | z                |
       | value:name:Ash | value:name:Misty | value:name:Brock |
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -1704,7 +1704,7 @@ Feature: Graql Insert Query
         $x isa name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1724,7 +1724,7 @@ Feature: Graql Insert Query
       $x isa person, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql insert
       """
@@ -1734,7 +1734,7 @@ Feature: Graql Insert Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1750,7 +1750,7 @@ Feature: Graql Insert Query
       $x isa person, has ref 0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql insert; throws exception
       """
@@ -1759,7 +1759,7 @@ Feature: Graql Insert Query
       insert
         $x isa company;
       """
-    Then the integrity is validated
+
 
 
   Scenario: inserting a new type on an existing instance that is a subtype of its existing type throws
@@ -1771,7 +1771,7 @@ Feature: Graql Insert Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1780,7 +1780,7 @@ Feature: Graql Insert Query
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert; throws exception
       """
@@ -1799,7 +1799,7 @@ Feature: Graql Insert Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1808,7 +1808,7 @@ Feature: Graql Insert Query
       insert $x isa child, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert; throws exception
       """
@@ -1828,7 +1828,7 @@ Feature: Graql Insert Query
         car sub entity;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1837,7 +1837,7 @@ Feature: Graql Insert Query
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert; throws exception
       """
@@ -1872,7 +1872,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1882,7 +1882,7 @@ Feature: Graql Insert Query
       $x isa person, has ref 0, has score 1.0;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1899,7 +1899,7 @@ Feature: Graql Insert Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1929,7 +1929,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1940,7 +1940,7 @@ Feature: Graql Insert Query
       $y isa person, has ref 1, has name "Freya";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -1958,7 +1958,7 @@ Feature: Graql Insert Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2008,7 +2008,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -2019,7 +2019,7 @@ Feature: Graql Insert Query
       $y 'G' isa letter;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -2039,7 +2039,7 @@ Feature: Graql Insert Query
         (lettered-name: $x, initial: $y) isa name-initial;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql delete
       """
@@ -2049,7 +2049,7 @@ Feature: Graql Insert Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2085,7 +2085,7 @@ Feature: Graql Insert Query
       employment owns ref;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Given graql define
       """
@@ -2108,7 +2108,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -2119,7 +2119,7 @@ Feature: Graql Insert Query
       $c isa contract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When get answers of graql match
       """
@@ -2136,7 +2136,7 @@ Feature: Graql Insert Query
         (employment: $e, contract: $c) isa employment-contract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open schema session for database: grakn
     When session opens transaction of type: write
@@ -2146,7 +2146,7 @@ Feature: Graql Insert Query
       rule henry-is-employed;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2213,7 +2213,7 @@ Feature: Graql Insert Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -2232,7 +2232,7 @@ Feature: Graql Insert Query
       (coordinate: $c, coordinate: $d) isa link;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert
       """
@@ -2245,7 +2245,7 @@ Feature: Graql Insert Query
         (proposal-to-construct: $r) isa road-construction;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql delete
       """
@@ -2256,7 +2256,7 @@ Feature: Graql Insert Query
         $r isa link;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     # After deleting all the links to 'c', our rules no longer infer that 'd' is reachable from 'a'. But in fact we
     # materialised this reachable link when we did our match-insert, because it played a role in our road-proposal,
@@ -2294,7 +2294,7 @@ Feature: Graql Insert Query
       employment owns ref;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -2305,7 +2305,7 @@ Feature: Graql Insert Query
       $y isa company;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql insert
       """
@@ -2317,7 +2317,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -2329,7 +2329,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -2341,7 +2341,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -2353,7 +2353,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -2365,7 +2365,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     When graql insert
       """
@@ -2377,7 +2377,7 @@ Feature: Graql Insert Query
         (employee: $z, employer: $y) isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2406,7 +2406,7 @@ Feature: Graql Insert Query
       insert
       $y qwertyuiop;
       """
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2425,7 +2425,7 @@ Feature: Graql Insert Query
       capacity sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -2439,7 +2439,7 @@ Feature: Graql Insert Query
       insert
       $y isa person, has name "Emily", has capacity 1000;
       """
-    Then the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -2459,7 +2459,7 @@ Feature: Graql Insert Query
       insert
       $y isa person, has name "Emily", has ref 0;
       """
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -2482,7 +2482,7 @@ Feature: Graql Insert Query
       bird sub entity;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     When session opens transaction of type: write
@@ -2492,4 +2492,4 @@ Feature: Graql Insert Query
       $x isa bird;
       $x iid V123;
       """
-    Then the integrity is validated
+

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -24,7 +24,7 @@ Feature: Graql Match Query
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -50,7 +50,7 @@ Feature: Graql Match Query
       ref sub attribute, value long;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
 
 
@@ -66,7 +66,7 @@ Feature: Graql Match Query
       scifi-writer sub writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -85,7 +85,7 @@ Feature: Graql Match Query
       scifi-writer sub writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -106,7 +106,7 @@ Feature: Graql Match Query
       scifi-writer sub writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -137,7 +137,7 @@ Feature: Graql Match Query
       telecoms-business-strategist sub telecoms-worker;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -153,7 +153,7 @@ Feature: Graql Match Query
       $g isa worker, has name "Gary", has ref 6;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -189,7 +189,7 @@ Feature: Graql Match Query
       flutist sub musician;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -209,7 +209,7 @@ Feature: Graql Match Query
       scifi-writer sub writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -234,7 +234,7 @@ Feature: Graql Match Query
       sub6 sub sub5;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -266,7 +266,7 @@ Feature: Graql Match Query
       unit sub attribute, value string, owns unit;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -286,7 +286,7 @@ Feature: Graql Match Query
       club sub entity, owns club-name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -307,7 +307,7 @@ Feature: Graql Match Query
       club sub entity, owns club-name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -337,7 +337,7 @@ Feature: Graql Match Query
       employment owns name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -350,7 +350,7 @@ Feature: Graql Match Query
       $w (employee: $x, employer: $y) isa employment, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -384,7 +384,7 @@ Feature: Graql Match Query
       friendly-person sub entity, plays close-friendship:close-friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -403,7 +403,7 @@ Feature: Graql Match Query
       friendly-person sub entity, plays close-friendship:close-friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -434,7 +434,7 @@ Feature: Graql Match Query
         owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -446,7 +446,7 @@ Feature: Graql Match Query
       $z isa dog, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -468,7 +468,7 @@ Feature: Graql Match Query
       dog sub entity, owns breed @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -498,7 +498,7 @@ Feature: Graql Match Query
       cat sub entity, owns breed;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -529,7 +529,7 @@ Feature: Graql Match Query
       friendly-person sub entity, plays close-friendship:close-friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -548,7 +548,7 @@ Feature: Graql Match Query
       friendly-person sub entity, plays close-friendship:close-friend;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -597,7 +597,7 @@ Feature: Graql Match Query
       $_ isa person, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -627,7 +627,7 @@ Feature: Graql Match Query
       good-scifi-writer sub scifi-writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -640,7 +640,7 @@ Feature: Graql Match Query
       $w isa good-scifi-writer, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -662,7 +662,7 @@ Feature: Graql Match Query
       good-scifi-writer sub scifi-writer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -675,7 +675,7 @@ Feature: Graql Match Query
       $w isa good-scifi-writer, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -696,7 +696,7 @@ Feature: Graql Match Query
       $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -722,7 +722,7 @@ Feature: Graql Match Query
       match $x isa ganesh;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: when matching by a relation type whose label doesn't exist, an error is thrown
@@ -731,7 +731,7 @@ Feature: Graql Match Query
       match ($x, $y) isa $type; $type type jakas-relacja;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: when matching a non-existent type label to a variable from a generic 'isa' query, an error is thrown
@@ -740,7 +740,7 @@ Feature: Graql Match Query
       match $x isa $type; $type type polok;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: when one entity exists, and we match two variables both of that entity type, the entity is returned
@@ -752,7 +752,7 @@ Feature: Graql Match Query
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -770,7 +770,7 @@ Feature: Graql Match Query
       """
       match $x isa friendship:friend;
       """
-    Then the integrity is validated
+
 
 
   @ignore # TODO we can't query for rule anymore
@@ -786,14 +786,14 @@ Feature: Graql Match Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then graql match; throws exception
       """
       match $x isa metre-rule;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   #############
@@ -813,7 +813,7 @@ Feature: Graql Match Query
          has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then get answers of graql match
       """
@@ -844,7 +844,7 @@ Feature: Graql Match Query
          has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -867,7 +867,7 @@ Feature: Graql Match Query
       $r (employee: $p, employer: $c, employer: $c2) isa employment, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then get answers of graql match
       """
@@ -891,7 +891,7 @@ Feature: Graql Match Query
       symmetric sub relation, relates player, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -900,7 +900,7 @@ Feature: Graql Match Query
       insert $x isa some-entity, has ref 0; (player: $x, player: $x) isa symmetric, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -919,7 +919,7 @@ Feature: Graql Match Query
       symmetric sub relation, relates player, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -928,7 +928,7 @@ Feature: Graql Match Query
       insert $x isa some-entity, has ref 0; (player: $x, player: $x) isa symmetric, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -951,7 +951,7 @@ Feature: Graql Match Query
       (friend: $x, friend: $y) isa friendship, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -973,7 +973,7 @@ Feature: Graql Match Query
         plays gift-delivery:recipient;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -991,7 +991,7 @@ Feature: Graql Match Query
       (sender: $x2a, recipient: $x2b) isa gift-delivery;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1022,7 +1022,7 @@ Feature: Graql Match Query
       person plays residency:resident;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1035,7 +1035,7 @@ Feature: Graql Match Query
       $r (resident: $x) isa residency, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Given get answers of graql match
       """
@@ -1067,7 +1067,7 @@ Feature: Graql Match Query
       match (person: $x) isa relation;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   # TODO: fix - query does not throw exception, but it should
@@ -1078,7 +1078,7 @@ Feature: Graql Match Query
       match ($x) isa person;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: an error is thrown when matching a non-existent type label as if it were a relation type
@@ -1087,7 +1087,7 @@ Feature: Graql Match Query
       match ($x) isa bottle-of-rum;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: when matching a role type that doesn't exist, an error is thrown
@@ -1096,7 +1096,7 @@ Feature: Graql Match Query
       match (rolein-rolein-rolein: $rolein) isa relation;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: when matching a role in a relation type that doesn't have that role, an error is thrown
@@ -1105,7 +1105,7 @@ Feature: Graql Match Query
       match (friend: $x) isa employment;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   # TODO: re-enable when fixed (it doesn't throw)
@@ -1118,7 +1118,7 @@ Feature: Graql Match Query
       ($x) isa friendship;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
   Scenario: Relations can be queried with pairings of relation and role types that are not directly related to each other
     Given graql define
@@ -1130,7 +1130,7 @@ Feature: Graql Match Query
       civil-marriage sub marriage;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1143,7 +1143,7 @@ Feature: Graql Match Query
       (spouse: $a, spouse: $b) isa civil-marriage;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1218,7 +1218,7 @@ Feature: Graql Match Query
       define <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1227,7 +1227,7 @@ Feature: Graql Match Query
       insert $n <value> isa <attr>, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1252,7 +1252,7 @@ Feature: Graql Match Query
       define <attr> sub attribute, value <type>, owns ref @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1281,7 +1281,7 @@ Feature: Graql Match Query
       $z "Fun Facts about Space" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1305,7 +1305,7 @@ Feature: Graql Match Query
       $z "Mr. Bean" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1329,7 +1329,7 @@ Feature: Graql Match Query
       $z "9" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1369,7 +1369,7 @@ Feature: Graql Match Query
       $y isa person, has name 'alice', has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1395,7 +1395,7 @@ Feature: Graql Match Query
       $d isa company, has ref 3;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1415,7 +1415,7 @@ Feature: Graql Match Query
       person owns shoe-size;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1427,7 +1427,7 @@ Feature: Graql Match Query
       $z isa person, has age 12, has shoe-size 12, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1448,7 +1448,7 @@ Feature: Graql Match Query
       person owns graduation-date;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1463,7 +1463,7 @@ Feature: Graql Match Query
       $u 2019-06-03 isa graduation-date, has age 22, has ref 5;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1484,7 +1484,7 @@ Feature: Graql Match Query
       person owns lucky-number;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1494,7 +1494,7 @@ Feature: Graql Match Query
       $x isa person, has lucky-number 10, has lucky-number 20, has lucky-number 30, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1512,7 +1512,7 @@ Feature: Graql Match Query
       unit sub attribute, value string, owns unit, owns ref;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1522,7 +1522,7 @@ Feature: Graql Match Query
       $x "meter" isa unit, has $x, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1541,7 +1541,7 @@ Feature: Graql Match Query
       match $x has person "Luke";
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   # TODO: re-enable when fixed (it doesn't throw)
@@ -1552,7 +1552,7 @@ Feature: Graql Match Query
       match $x isa company, has age $n;
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   Scenario: an error is thrown when matching by attribute ownership, when the owned type label doesn't exist
@@ -1561,7 +1561,7 @@ Feature: Graql Match Query
       match $x has bananananananana "rama";
       """
     Then session transaction is open: false
-    Then the integrity is validated
+
 
 
   ##############################
@@ -1578,7 +1578,7 @@ Feature: Graql Match Query
       employment owns start-date;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1589,7 +1589,7 @@ Feature: Graql Match Query
       $r (employee: $x) isa employment, has start-date 2009-07-16, has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Then get answers of graql match
       """
@@ -1615,7 +1615,7 @@ Feature: Graql Match Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1638,7 +1638,7 @@ Feature: Graql Match Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1661,7 +1661,7 @@ Feature: Graql Match Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1684,7 +1684,7 @@ Feature: Graql Match Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1704,7 +1704,7 @@ Feature: Graql Match Query
       length sub attribute, value double;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1715,7 +1715,7 @@ Feature: Graql Match Query
       $y 2.0 isa length;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1769,7 +1769,7 @@ Feature: Graql Match Query
       person owns lucky-number;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1779,7 +1779,7 @@ Feature: Graql Match Query
       $x isa person, has lucky-number 10, has lucky-number 20, has lucky-number 30, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1802,7 +1802,7 @@ Feature: Graql Match Query
       $z isa person, has name "Ralph", has age 18, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1825,7 +1825,7 @@ Feature: Graql Match Query
       length sub attribute, value double;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1838,7 +1838,7 @@ Feature: Graql Match Query
       $d 19.9 isa length;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1861,7 +1861,7 @@ Feature: Graql Match Query
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1894,7 +1894,7 @@ Feature: Graql Match Query
       $y isa company, has name "Amazon", has ref 1;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     When get answers of graql match
       """
@@ -1922,7 +1922,7 @@ Feature: Graql Match Query
       $r (friend: $x, friend: $y) isa friendship, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Given get answers of graql match
       """
@@ -1961,7 +1961,7 @@ Feature: Graql Match Query
       $r (friend: $x, friend: $y) isa friendship, has ref 2;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Given get answers of graql match
       """

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -34,7 +34,7 @@ Feature: Graql Rule Validation
       email sub attribute, value string;
       start-date sub attribute, value datetime;
       """
-    Given the integrity is validated
+
 
 
   # Note: These tests verify only the ability to create rules, and are not concerned with their application.
@@ -51,7 +51,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Given the integrity is validated
+
     When get answers of graql match
       """
       match $x sub rule;
@@ -73,7 +73,7 @@ Feature: Graql Rule Validation
         $p has email "john.smith@gmail.com";
       };
       """
-    Given the integrity is validated
+
     When get answers of graql match
       """
       match $x sub rule;
@@ -95,7 +95,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has no 'then' clause, an error is thrown
@@ -108,7 +108,7 @@ Feature: Graql Rule Validation
         $p has name "Robert";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule's 'when' clause is empty, an error is thrown
@@ -123,7 +123,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule's 'then' clause is empty, an error is thrown
@@ -137,7 +137,7 @@ Feature: Graql Rule Validation
       } then {
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: a rule can have negation in its 'when' clause
@@ -156,7 +156,7 @@ Feature: Graql Rule Validation
         $p has only-child true;
       };
       """
-    Given the integrity is validated
+
     When get answers of graql match
       """
       match $x sub rule;
@@ -182,7 +182,7 @@ Feature: Graql Rule Validation
         $register has has-robert false;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has nested negation, an error is thrown
@@ -203,7 +203,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has multiple negations, an error is thrown
@@ -225,7 +225,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
   Scenario: a rule can have a conjunction in a negation
     Then graql define throws
@@ -246,7 +246,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bob";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has two conclusions, an error is thrown
@@ -256,7 +256,7 @@ Feature: Graql Rule Validation
       nickname sub name;
       person owns nickname;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -267,7 +267,7 @@ Feature: Graql Rule Validation
         $p has nickname "Bobby";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: a rule can use conjunction in its 'when' clause
@@ -283,7 +283,7 @@ Feature: Graql Rule Validation
         (named-robert: $p, named-robert: $p2) isa both-named-robert;
       };
       """
-    Given the integrity is validated
+
     When get answers of graql match
       """
       match $x sub rule;
@@ -301,7 +301,7 @@ Feature: Graql Rule Validation
       nickname sub name;
       person owns nickname;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -312,7 +312,7 @@ Feature: Graql Rule Validation
         $p has nickname "Fi";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule contains an unbound variable in the 'then' clause, an error is thrown
@@ -322,7 +322,7 @@ Feature: Graql Rule Validation
       nickname sub name;
       person owns nickname;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -332,7 +332,7 @@ Feature: Graql Rule Validation
         $q has nickname "Who am I?";
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has an undefined attribute set in its 'then' clause, an error is thrown
@@ -345,7 +345,7 @@ Feature: Graql Rule Validation
         $person has age 1960;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule attaches an attribute to a type that can't have that attribute, an error is thrown
@@ -359,7 +359,7 @@ Feature: Graql Rule Validation
         $person has age 1960;
       };
       """
-    Then the integrity is validated
+
 
 
   @ignore
@@ -371,7 +371,7 @@ Feature: Graql Rule Validation
       nickname sub name;
       person owns nickname;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -381,7 +381,7 @@ Feature: Graql Rule Validation
         $p has nickname 5;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule infers a relation whose type doesn't exist, an error is thrown
@@ -395,7 +395,7 @@ Feature: Graql Rule Validation
         (criminal: $bonnie, sidekick: $clyde) isa partners-in-crime;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule infers a relation with an incorrect roleplayer, an error is thrown
@@ -411,7 +411,7 @@ Feature: Graql Rule Validation
         (criminal: $bonnie, sidekick: $clyde) isa partners-in-crime;
       };
       """
-    Then the integrity is validated
+
 
   @ignore
   # TODO: re-enable when rules cannot infer abstract relations
@@ -428,7 +428,7 @@ Feature: Graql Rule Validation
         (criminal: $bonnie, sidekick: $clyde) isa partners-in-crime;
       };
       """
-    Then the integrity is validated
+
 
 
   @ignore
@@ -445,7 +445,7 @@ Feature: Graql Rule Validation
         $karl has number-of-devices 0;
       };
       """
-    Then the integrity is validated
+
 
 
 
@@ -467,7 +467,7 @@ Feature: Graql Rule Validation
       $p has nickname "Bobby";
     };
     """
-    Then the integrity is validated
+
 
 
   Scenario: when defining a rule to generate new entities from existing ones, an error is thrown
@@ -478,7 +478,7 @@ Feature: Graql Rule Validation
       baseEntity sub entity;
       derivedEntity sub entity;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -488,7 +488,7 @@ Feature: Graql Rule Validation
           $y isa derivedEntity;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when defining a rule to generate new entities from existing relations, an error is thrown
@@ -508,7 +508,7 @@ Feature: Graql Rule Validation
           relates role1,
           relates role2;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -519,7 +519,7 @@ Feature: Graql Rule Validation
           $u isa derivedEntity;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when defining a rule to generate new relations from existing ones, an error is thrown
@@ -535,7 +535,7 @@ Feature: Graql Rule Validation
           relates role1,
           relates role2;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -546,7 +546,7 @@ Feature: Graql Rule Validation
           $u (role1:$x, role2:$z) isa baseRelation;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when defining a rule to infer an additional type that is missing a necessary attribute, an error is thrown
@@ -555,7 +555,7 @@ Feature: Graql Rule Validation
       define
       dog sub entity;
       """
-    Given the integrity is validated
+
     Then graql define throws
       """
       define
@@ -565,7 +565,7 @@ Feature: Graql Rule Validation
         $x isa dog;
       };
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule negates its conclusion in the 'when', causing a loop, an error is thrown
@@ -582,7 +582,7 @@ Feature: Graql Rule Validation
         (employee: $person) isa employment;
       };
       """
-    Then the integrity is validated
+
 
   Scenario: when a rule negates itself, but only in the rule body, the rule commits
     Given graql define
@@ -595,7 +595,7 @@ Feature: Graql Rule Validation
         (employee: $p) isa employment;
       };
       """
-    Then the integrity is validated
+
 
     Scenario: when a rule negates itself in the rule body, the rule commits even if that cycle involves a then clause in another rule
       Given graql define
@@ -616,7 +616,7 @@ Feature: Graql Rule Validation
         (employee: $p) isa employment;
       };
       """
-      Then the integrity is validated
+
 
     Scenario: When multiple rules cause a loop with a negation, an error is thrown
       Then graql define throws
@@ -640,7 +640,7 @@ Feature: Graql Rule Validation
         (employee: $person) isa employment;
       };
       """
-      Then the integrity is validated
+
 
     Scenario: rules with cyclic inferences are allowed as long as there is no negation
       When graql define
@@ -662,7 +662,7 @@ Feature: Graql Rule Validation
         (employee: $p) isa employment;
       };
       """
-      Then the integrity is validated
+
 
 
 
@@ -681,7 +681,7 @@ Feature: Graql Rule Validation
     };
 
     """
-    Then the integrity is validated
+
 
 
   Scenario: when a rule has a down-cast in a rule conclusion, an error is thrown
@@ -700,7 +700,7 @@ Feature: Graql Rule Validation
         $p isa man;
       };
       """
-    Then the integrity is validated
+
 
 
     Scenario: when a rule has a side-cast in a rule, an error is thrown
@@ -724,7 +724,7 @@ Feature: Graql Rule Validation
         $p isa boy;
       };
       """
-      Then the integrity is validated
+
 
 
   Scenario: when a rule adds a role to an existing relation, an error is thrown
@@ -741,7 +741,7 @@ Feature: Graql Rule Validation
         $r (employee: $p) isa employment;
       };
       """
-    Then the integrity is validated
+
 
   Scenario: if a rule's body uses a type that doesn't exist, an error is thrown
     When graql define throws
@@ -755,7 +755,7 @@ Feature: Graql Rule Validation
         (employee: $m) isa employment;
       };
       """
-    Then the integrity is validated
+
 
   Scenario: if a rule that uses a missing type within a negation, an error is thrown
     When graql define throws
@@ -770,7 +770,7 @@ Feature: Graql Rule Validation
         (employee: $p) isa employment;
       };
       """
-    Then the integrity is validated
+
 
   Scenario: a rule may infer a named variable for an attribute if the attribute type is left out
     When graql define
@@ -786,7 +786,7 @@ Feature: Graql Rule Validation
         $p has $bob;
       };
       """
-    Then the integrity is validated
+
 
   Scenario: a rule may infer an attribute type when the value is concrete
     When graql define
@@ -801,7 +801,7 @@ Feature: Graql Rule Validation
         $p has nickname 'bob';
       };
     """
-    Then the integrity is validated
+
 
   Scenario: if a rule infers both an attribute type and a named variable, an error is thrown
     When graql define throws
@@ -817,7 +817,7 @@ Feature: Graql Rule Validation
         $p has nickname $b;
       };
     """
-    Then the integrity is validated
+
 
   Scenario: a rule may have a clause asserting both an attribute type and a named variable within its when clause
     When graql define
@@ -840,5 +840,5 @@ Feature: Graql Rule Validation
       (relative: $p, relative: $q) isa family-relation;
     };
     """
-    Then the integrity is validated
+
 

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -24,7 +24,7 @@ Feature: Graql Undefine Query
     Given connection create database: grakn
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
-    Given the integrity is validated
+
     Given graql define
       """
       define
@@ -35,7 +35,7 @@ Feature: Graql Undefine Query
       abstract-type sub entity, abstract;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
 
 
@@ -58,7 +58,7 @@ Feature: Graql Undefine Query
       undefine person sub entity;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -75,7 +75,7 @@ Feature: Graql Undefine Query
       """
       undefine person sub relation;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a sub-entity type can be removed using 'sub' with its direct supertype, and its parent is preserved
@@ -84,7 +84,7 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Given get answers of graql match
       """
@@ -99,7 +99,7 @@ Feature: Graql Undefine Query
       undefine child sub person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -116,7 +116,7 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -132,7 +132,7 @@ Feature: Graql Undefine Query
       undefine child sub entity;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -149,13 +149,13 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Then graql undefine; throws exception
       """
       undefine person sub entity;
       """
-    Then the integrity is validated
+
 
 
   Scenario: removing a playable role from a super entity type also removes it from its subtypes
@@ -164,14 +164,14 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql undefine
       """
       undefine person plays employment:employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -186,14 +186,14 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql undefine
       """
       undefine person owns name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -208,14 +208,14 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql undefine
       """
       undefine person owns email;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -236,7 +236,7 @@ Feature: Graql Undefine Query
       | label:person        |
       | label:entity        |
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -245,7 +245,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has name "Victor", has email "victor@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     When session opens transaction of type: write
@@ -253,7 +253,7 @@ Feature: Graql Undefine Query
       """
       undefine person sub entity;
       """
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -265,7 +265,7 @@ Feature: Graql Undefine Query
         $x isa person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open schema session for database: grakn
     When session opens transaction of type: write
@@ -274,7 +274,7 @@ Feature: Graql Undefine Query
       undefine person sub entity;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -304,7 +304,7 @@ Feature: Graql Undefine Query
       undefine employment sub relation;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -324,7 +324,7 @@ Feature: Graql Undefine Query
       contract-employment sub employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -338,7 +338,7 @@ Feature: Graql Undefine Query
       undefine employment plays employment-terms:employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -356,7 +356,7 @@ Feature: Graql Undefine Query
       contract-employment sub employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -371,7 +371,7 @@ Feature: Graql Undefine Query
       undefine employment owns start-date;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -389,7 +389,7 @@ Feature: Graql Undefine Query
       contract-employment sub employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -404,7 +404,7 @@ Feature: Graql Undefine Query
       undefine employment owns employment-reference;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -424,7 +424,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -436,7 +436,7 @@ Feature: Graql Undefine Query
       person plays employment:employee;
       employment sub relation;
       """
-    Then the integrity is validated
+
 
   #TODO: Reenable when deletion works
   @ignore
@@ -459,7 +459,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -467,7 +467,7 @@ Feature: Graql Undefine Query
       """
       undefine employment sub relation;
       """
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -479,7 +479,7 @@ Feature: Graql Undefine Query
         $r isa employment;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open schema session for database: grakn
     When session opens transaction of type: write
@@ -488,7 +488,7 @@ Feature: Graql Undefine Query
       undefine employment sub relation;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -514,7 +514,7 @@ Feature: Graql Undefine Query
       undefine employment sub relation;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -543,7 +543,7 @@ Feature: Graql Undefine Query
       undefine employment relates employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -560,7 +560,7 @@ Feature: Graql Undefine Query
       undefine person plays employment:employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -581,7 +581,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given graql delete
       """
@@ -591,7 +591,7 @@ Feature: Graql Undefine Query
         $r isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -602,7 +602,7 @@ Feature: Graql Undefine Query
       employment relates employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -618,7 +618,7 @@ Feature: Graql Undefine Query
       insert
         $r (employee: $p) isa employment;
       """
-    Then the integrity is validated
+
 
 
   Scenario: removing all roles from a relation type without undefining the relation type throws on commit
@@ -629,7 +629,7 @@ Feature: Graql Undefine Query
       employment relates employer;
       """
     Then transaction commits; throws exception
-    Then the integrity is validated
+
 
 
   Scenario: undefining a role type automatically detaches any possible roleplayers
@@ -647,7 +647,7 @@ Feature: Graql Undefine Query
       undefine employment relates employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -665,7 +665,7 @@ Feature: Graql Undefine Query
       company sub entity, owns name, plays employment:employer;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -677,7 +677,7 @@ Feature: Graql Undefine Query
       $r (employee: $p, employer: $c) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -685,7 +685,7 @@ Feature: Graql Undefine Query
       """
       undefine employment relates employer;
       """
-    Then the integrity is validated
+
 
 
   Scenario: a role that is not played in any existing instance of its relation type can be safely removed
@@ -699,7 +699,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -708,7 +708,7 @@ Feature: Graql Undefine Query
       undefine employment relates employer;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -725,14 +725,14 @@ Feature: Graql Undefine Query
       define part-time sub employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     When graql undefine
       """
       undefine employment relates employer;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -766,7 +766,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given graql delete
       """
@@ -776,7 +776,7 @@ Feature: Graql Undefine Query
         $r isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -785,7 +785,7 @@ Feature: Graql Undefine Query
       undefine person plays employment:employee;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -801,7 +801,7 @@ Feature: Graql Undefine Query
       insert
         $r (employee: $p) isa employment;
       """
-    Then the integrity is validated
+
 
 
   Scenario: undefining a playable role that was not actually playable to begin with throws
@@ -816,7 +816,7 @@ Feature: Graql Undefine Query
       """
       undefine person plays employment:employer;
       """
-    Then the integrity is validated
+
 
 
   Scenario: removing a playable role throws an error if it is played by existing instances
@@ -830,7 +830,7 @@ Feature: Graql Undefine Query
       $r (employee: $p) isa employment;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -838,7 +838,7 @@ Feature: Graql Undefine Query
       """
       undefine person plays employment:employee;
       """
-    Then the integrity is validated
+
 
 
   ###################
@@ -851,7 +851,7 @@ Feature: Graql Undefine Query
       define <attr> sub attribute, value <value_type>;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -863,7 +863,7 @@ Feature: Graql Undefine Query
       undefine <attr> sub attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     Then graql match; throws exception
       """
@@ -885,7 +885,7 @@ Feature: Graql Undefine Query
       undefine email regex ".+@\w+\..+";
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -894,7 +894,7 @@ Feature: Graql Undefine Query
       insert $x "not-email-regex" isa email;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -913,7 +913,7 @@ Feature: Graql Undefine Query
       name plays employment:manager-name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -927,7 +927,7 @@ Feature: Graql Undefine Query
       undefine name plays employment:manager-name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -946,7 +946,7 @@ Feature: Graql Undefine Query
       name owns locale;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -961,7 +961,7 @@ Feature: Graql Undefine Query
       undefine name owns locale;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -980,7 +980,7 @@ Feature: Graql Undefine Query
       name owns name-id @key;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     Given get answers of graql match
       """
@@ -995,7 +995,7 @@ Feature: Graql Undefine Query
       undefine name owns name-id;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1011,7 +1011,7 @@ Feature: Graql Undefine Query
       name owns name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql undefine
       """
@@ -1020,7 +1020,7 @@ Feature: Graql Undefine Query
       name sub attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     Then graql match; throws exception
       """
@@ -1033,7 +1033,7 @@ Feature: Graql Undefine Query
       """
       undefine name value string;
       """
-    Then the integrity is validated
+
 
   #TODO: Reenable when deletion works
   @ignore
@@ -1055,7 +1055,7 @@ Feature: Graql Undefine Query
       insert $x "Colette" isa name;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1063,7 +1063,7 @@ Feature: Graql Undefine Query
       """
       undefine name sub attribute;
       """
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open data session for database: grakn
     When session opens transaction of type: write
@@ -1075,7 +1075,7 @@ Feature: Graql Undefine Query
         $x isa name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When connection close all sessions
     When connection open schema session for database: grakn
     When session opens transaction of type: write
@@ -1084,7 +1084,7 @@ Feature: Graql Undefine Query
       undefine name sub attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1115,7 +1115,7 @@ Feature: Graql Undefine Query
       undefine person owns name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1131,7 +1131,7 @@ Feature: Graql Undefine Query
       """
       undefine employment owns name;
       """
-    Then the integrity is validated
+
 
 
   Scenario: attempting to undefine an attribute ownership inherited from a parent throws
@@ -1140,13 +1140,13 @@ Feature: Graql Undefine Query
       define child sub person;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: write
     Then graql undefine; throws exception
       """
       undefine child owns name;
       """
-    Then the integrity is validated
+
 
 
   Scenario: undefining a key ownership removes it
@@ -1155,7 +1155,7 @@ Feature: Graql Undefine Query
       undefine person owns email;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1169,7 +1169,7 @@ Feature: Graql Undefine Query
       """
       undefine person owns email @key;
       """
-    Then the integrity is validated
+
 
 
   Scenario: writing '@key' when undefining an attribute ownership is not allowed
@@ -1177,7 +1177,7 @@ Feature: Graql Undefine Query
       """
       undefine person owns name @key;
       """
-    Then the integrity is validated
+
 
 
   Scenario: when a type can own an attribute, but none of its instances actually do, the ownership can be undefined
@@ -1189,7 +1189,7 @@ Feature: Graql Undefine Query
       | x            |
       | label:person |
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1198,7 +1198,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has email "anon@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1207,7 +1207,7 @@ Feature: Graql Undefine Query
       undefine person owns name;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1225,7 +1225,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has name "Tomas", has email "tomas@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1233,7 +1233,7 @@ Feature: Graql Undefine Query
       """
       undefine person owns name;
       """
-    Then the integrity is validated
+
 
 
   Scenario: undefining a key ownership throws an error if it is owned by existing instances
@@ -1245,7 +1245,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has name "Daniel", has email "daniel@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1253,7 +1253,7 @@ Feature: Graql Undefine Query
       """
       undefine person owns email;
       """
-    Then the integrity is validated
+
 
 
   #########
@@ -1273,7 +1273,7 @@ Feature: Graql Undefine Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     When session opens transaction of type: write
     Then rules contain: a-rule
     When graql undefine
@@ -1281,7 +1281,7 @@ Feature: Graql Undefine Query
       undefine rule a-rule;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     Then rules do not contain: a-rule
 
@@ -1299,7 +1299,7 @@ Feature: Graql Undefine Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1308,7 +1308,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has email "samuel@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: read
     Given get answers of graql match
       """
@@ -1327,7 +1327,7 @@ Feature: Graql Undefine Query
       undefine rule samuel-email-rule;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1351,7 +1351,7 @@ Feature: Graql Undefine Query
       };
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1360,7 +1360,7 @@ Feature: Graql Undefine Query
       insert $x isa person, has email "samuel@grakn.ai";
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1377,7 +1377,7 @@ Feature: Graql Undefine Query
       """
       undefine rule samuel-email-rule;
       """
-    Then the integrity is validated
+
     When get answers of graql match
       """
       match
@@ -1408,7 +1408,7 @@ Feature: Graql Undefine Query
       """
       insert $x isa abstract-type;
       """
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open schema session for database: grakn
     Given session opens transaction of type: write
@@ -1417,7 +1417,7 @@ Feature: Graql Undefine Query
       undefine abstract-type abstract;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given connection close all sessions
     Given connection open data session for database: grakn
     Given session opens transaction of type: write
@@ -1435,7 +1435,7 @@ Feature: Graql Undefine Query
       insert $x isa abstract-type;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1450,7 +1450,7 @@ Feature: Graql Undefine Query
       undefine person abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1469,14 +1469,14 @@ Feature: Graql Undefine Query
       define sub-abstract-type sub abstract-type, abstract;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql undefine
       """
       undefine abstract-type abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1498,7 +1498,7 @@ Feature: Graql Undefine Query
       person owns vehicle-registration;
       """
     Given transaction commits
-    Given the integrity is validated
+
     Given session opens transaction of type: write
     When graql undefine
       """
@@ -1506,7 +1506,7 @@ Feature: Graql Undefine Query
       vehicle-registration abstract;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1547,7 +1547,7 @@ Feature: Graql Undefine Query
       name sub attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """
@@ -1610,7 +1610,7 @@ Feature: Graql Undefine Query
       name sub attribute;
       """
     Then transaction commits
-    Then the integrity is validated
+
     When session opens transaction of type: read
     When get answers of graql match
       """


### PR DESCRIPTION
## What is the goal of this PR?
Integrity validation steps were intended to check the state of the DB, after operations are committed. However, as this feature has not been implemented in 9months across the stack, and its value is still uncertain, we are remove all these steps.

## What are the changes implemented in this PR?
* Delete all steps to do with integrity validation