### PR TITLE
Update reasoning BDD for 2.0 - part 1

### DIFF
--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -36,7 +36,7 @@ Feature: Attribute Attachment Resolution
       | reasoned     |
     Given materialised session has database name: materialised
     Given reasoned session has database name: reasoned
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql define
       """
       define
@@ -70,7 +70,7 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 
   @Ignore
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -100,10 +100,10 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 #    When materialised database is completed
     Given transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -146,10 +146,10 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -34,8 +34,8 @@ Feature: Attribute Attachment Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given session opens transaction of type: write
     Given for each session, graql define
       """
@@ -70,7 +70,6 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: write
 
   @Ignore
@@ -101,11 +100,9 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: write
 #    When materialised database is completed
     Given transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -149,11 +146,9 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -34,7 +34,7 @@ Feature: Attribute Attachment Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -68,7 +68,7 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
 
   @Ignore
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -95,7 +95,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -104,10 +104,10 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -147,7 +147,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -156,10 +156,10 @@ Feature: Attribute Attachment Resolution
       $z isa soft-drink, has name "Tango";
       """
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -71,7 +71,6 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
 
   @Ignore
-  # TODO: re-enable all steps once attribute re-attachment is resolvable
   # TODO: move to negation.feature
   Scenario: when matching a pair of unrelated inferred attributes with negation and =, the answers are unequal
     Given for each session, graql define
@@ -115,16 +114,15 @@ Feature: Attribute Attachment Resolution
         $y has string-attribute $sa;
         not { $re = $sa; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # The string-attributes are transferred to each other, so in fact both people have both Tesco and Safeway
     # x     | re    | y     | sa      |
     # Tango | Tesco | Alice | Safeway |
     # Tango | Tesco | Bob   | Safeway |
     Then answer size in reasoned database is: 2
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
   @Ignore
-   # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: when matching a pair of unrelated inferred attributes with '!=', the answers are unequal
     Given for each session, graql define
       """
@@ -167,10 +165,10 @@ Feature: Attribute Attachment Resolution
         $y has string-attribute $sa;
         $re != $sa;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # The string-attributes are transferred to each other, so in fact both people have both Tesco and Safeway
     # x     | re    | y     | sa      |
     # Tango | Tesco | Alice | Safeway |
     # Tango | Tesco | Bob   | Safeway |
     Then answer size in reasoned database is: 2
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -34,9 +34,7 @@ Feature: Attribute Attachment Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -70,7 +68,7 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 
   @Ignore
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -92,6 +90,14 @@ Feature: Attribute Attachment Resolution
         $x has retailer 'Tesco';
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -99,11 +105,11 @@ Feature: Attribute Attachment Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
-    Given transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
 #    When materialised database is completed
     Given transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -138,6 +144,14 @@ Feature: Attribute Attachment Resolution
         $x has retailer 'Tesco';
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -145,11 +159,11 @@ Feature: Attribute Attachment Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
-    Given transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given sessions open transactions with reasoning of type: read
 #    When materialised database is completed
-    Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -25,14 +25,18 @@
 
 #noinspection CucumberUndefinedStep
 Feature: Attribute Attachment Resolution
-  Background: Set up databases for resolution testing
 
+  Background: Set up databases for resolution testing
     Given connection has been opened
+    Given connection does not have any database
+    Given connection create database: reasoned
+    Given connection create database: materialised
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
     Given materialised database is named: materialised
     Given reasoned database is named: reasoned
+    Given session opens transaction of type: write
     Given for each session, graql define
       """
       define
@@ -65,129 +69,9 @@ Feature: Attribute Attachment Resolution
       sub-string-attribute sub string-attribute;
       unrelated-attribute sub attribute, value string;
       """
-
-      # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
-  @Ignore
-  Scenario: when multiple rules copy attributes from an entity, they all get resolved
-    Given for each session, graql define
-      """
-      define
-      rule transfer-string-attribute-to-other-people: when {
-        $x isa person, has string-attribute $r1;
-        $y isa person;
-      } then {
-        $y has string-attribute $r1;
-      };
-
-      rule transfer-attribute-value-to-sub-attribute: when {
-        $x isa person, has string-attribute $r1;
-      } then {
-        $x has sub-string-attribute $r1;
-      };
-
-      rule transfer-attribute-value-to-unrelated-attribute: when {
-        $x isa person, has string-attribute $r1;
-        $r2 isa unrelated-attribute;
-      } then {
-        $x has unrelated-attribute $r1;
-      };
-      """
-    Given for each session, graql insert
-      """
-      insert
-      $geX isa person, has string-attribute "banana";
-      $geY isa person;
-      """
-#    When materialised database is completed
-    Then for graql query
-      """
-      match $x isa person;
-      """
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 2
-    Then for graql query
-      """
-      match $x isa person, has attribute $y;
-      """
-    # four attributes for each entity
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 6
-#    Then materialised and reasoned databases are the same size
-
-
-  @Ignore
-   # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
-  Scenario: when a rule copies an attribute value to its sub-attribute, a new attribute concept is inferred
-    Given for each session, graql define
-      """
-      define
-      rule transfer-attribute-value-to-sub-attribute: when {
-        $x isa person, has string-attribute $r1;
-      } then {
-        $x has sub-string-attribute $r1;
-      };
-      """
-    Given for each session, graql insert
-      """
-      insert
-      $geX isa person, has string-attribute "banana";
-      """
-#    When materialised database is completed
-    Then for graql query
-      """
-      match $x isa person, has sub-string-attribute $y;
-      """
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 1
-    Then for graql query
-      """
-      match $x isa sub-string-attribute;
-      """
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 1
-    Then for graql query
-      """
-      match $x isa string-attribute; $y isa sub-string-attribute;
-      """
-    # 2 SA instances - one base, one sub hence two answers
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 2
-#    Then materialised and reasoned databases are the same size
-
-
-  @Ignore
-  # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
-  Scenario: when a rule copies an attribute value to an unrelated attribute, a new attribute concept is inferred
-    Given for each session, graql define
-      """
-      define
-      rule transfer-attribute-value-to-unrelated-attribute: when {
-        $x isa person, has string-attribute $r1;
-      } then {
-        $x has unrelated-attribute $r1;
-      };
-      """
-    Given for each session, graql insert
-      """
-      insert
-      $geX isa person, has string-attribute "banana";
-      $geY isa person;
-      """
-#    When materialised database is completed
-    Then for graql query
-      """
-      match $x isa person, has unrelated-attribute $y;
-      """
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 1
-    Then for graql query
-      """
-      match $x isa unrelated-attribute;
-      """
-#    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 1
-#    Then materialised and reasoned databases are the same size
-
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
 
   @Ignore
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -216,7 +100,13 @@ Feature: Attribute Attachment Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
 #    When materialised database is completed
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -258,7 +148,13 @@ Feature: Attribute Attachment Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/arithmetic-equality.feature
+++ b/graql/reasoner/arithmetic-equality.feature
@@ -95,8 +95,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -107,7 +105,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -149,8 +147,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -161,7 +157,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -26,7 +26,7 @@ Feature: Attribute Attachment Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -58,10 +58,9 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 
 
-  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: when a rule copies an attribute from one entity to another, the existing attribute instance is reused
     Given for each session, graql define
       """
@@ -80,7 +79,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -88,10 +87,10 @@ Feature: Attribute Attachment Resolution
       $geY isa person;
       """
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has string-attribute $y;
@@ -99,7 +98,7 @@ Feature: Attribute Attachment Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa string-attribute;
@@ -137,7 +136,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -146,10 +145,10 @@ Feature: Attribute Attachment Resolution
       (leader:$geX, member:$geX) isa team;
       """
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has string-attribute $y;
@@ -186,7 +185,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -195,18 +194,25 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Ocado';
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+#    Then sleep
     Then for each session, transaction closes
-    Given session opens transactions with reasoning of type: read
+    Then connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer $r;
@@ -214,7 +220,7 @@ Feature: Attribute Attachment Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Tesco';
@@ -243,7 +249,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -252,10 +258,10 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: write
+    Given sessions open transactions of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado';

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -26,7 +26,7 @@ Feature: Attribute Attachment Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -58,7 +58,7 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
 
 
   Scenario: when a rule copies an attribute from one entity to another, the existing attribute instance is reused
@@ -77,7 +77,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -85,10 +85,10 @@ Feature: Attribute Attachment Resolution
       $geY isa person;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has string-attribute $y;
@@ -96,7 +96,7 @@ Feature: Attribute Attachment Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa string-attribute;
@@ -132,7 +132,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -141,10 +141,10 @@ Feature: Attribute Attachment Resolution
       (leader:$geX, member:$geX) isa team;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has string-attribute $y;
@@ -179,7 +179,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -188,10 +188,10 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Ocado';
@@ -204,7 +204,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer $r;
@@ -212,7 +212,7 @@ Feature: Attribute Attachment Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Tesco';
@@ -239,7 +239,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -248,10 +248,10 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado';

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -93,7 +93,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x isa person, has string-attribute $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -101,14 +101,12 @@ Feature: Attribute Attachment Resolution
       """
       match $x isa string-attribute;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
     Then for each session, transaction closes
 
 
-
-  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: when the same attribute is inferred on an entity and relation, both owners are correctly retrieved
     Given for each session, graql define
       """
@@ -149,11 +147,10 @@ Feature: Attribute Attachment Resolution
       """
       match $x has string-attribute $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
     Then for each session, transaction closes
-
 
 
   Scenario: a rule can infer an attribute value that did not previously exist in the graph
@@ -198,7 +195,6 @@ Feature: Attribute Attachment Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-#    Then sleep
     Then for each session, transaction closes
     Then connection close all sessions
     Given connection open data sessions for databases:

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -19,13 +19,16 @@
 Feature: Attribute Attachment Resolution
 
   Background: Set up databases for resolution testing
-
     Given connection has been opened
-    Given connection open sessions for databases:
-      | materialised |
-      | reasoned     |
-    Given materialised database is named: materialised
+    Given connection does not have any database
+    Given connection create database: reasoned
+    Given connection create database: materialised
     Given reasoned database is named: reasoned
+    Given materialised database is named: materialised
+    Given connection open schema sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given session opens transaction of type: write
     Given for each session, graql define
       """
       define
@@ -35,7 +38,6 @@ Feature: Attribute Attachment Resolution
           plays team:member,
           owns string-attribute,
           owns unrelated-attribute,
-          owns sub-string-attribute,
           owns age,
           owns is-old;
 
@@ -55,9 +57,11 @@ Feature: Attribute Attachment Resolution
       retailer sub attribute, value string;
       age sub attribute, value long;
       is-old sub attribute, value boolean;
-      sub-string-attribute sub string-attribute;
       unrelated-attribute sub attribute, value string;
       """
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -78,13 +82,22 @@ Feature: Attribute Attachment Resolution
       $geX isa person, has string-attribute "banana";
       $geY isa person;
       """
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa person, has string-attribute $y;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa string-attribute;
@@ -120,7 +133,13 @@ Feature: Attribute Attachment Resolution
       $geY isa person;
       (leader:$geX, team-member:$geX) isa team;
       """
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has string-attribute $y;
@@ -155,19 +174,29 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
+#    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has retailer 'Ocado';
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has retailer $r;
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
+    Given the transaction commits
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has retailer 'Tesco';
@@ -196,7 +225,13 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: write
+#    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado';

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -23,8 +23,6 @@ Feature: Attribute Attachment Resolution
     Given connection does not have any database
     Given connection create database: reasoned
     Given connection create database: materialised
-    Given reasoned database is named: reasoned
-    Given materialised database is named: materialised
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
@@ -59,8 +57,7 @@ Feature: Attribute Attachment Resolution
       is-old sub attribute, value boolean;
       unrelated-attribute sub attribute, value string;
       """
-    Given transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: write
 
 
@@ -76,18 +73,24 @@ Feature: Attribute Attachment Resolution
         $y has $r1;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given session opens transaction of type: write
     Given for each session, graql insert
       """
       insert
       $geX isa person, has string-attribute "banana";
       $geY isa person;
       """
-    Given transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: write
 #    When materialised database is completed
-    Given the transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -95,8 +98,7 @@ Feature: Attribute Attachment Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given the transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -126,19 +128,25 @@ Feature: Attribute Attachment Resolution
         $z has $y;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given session opens transaction of type: write
     Given for each session, graql insert
       """
       insert
       $geX isa person, has string-attribute "banana";
       $geY isa person;
-      (leader:$geX, team-member:$geX) isa team;
+      (leader:$geX, member:$geX) isa team;
       """
-    Given transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: write
 #    When materialised database is completed
-    Given the transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -167,6 +175,14 @@ Feature: Attribute Attachment Resolution
         $y has retailer 'Ocado';
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given session opens transaction of type: write
     Given for each session, graql insert
       """
       insert
@@ -174,12 +190,10 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    Given transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: write
 #    When materialised database is completed
-    Given the transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -187,7 +201,7 @@ Feature: Attribute Attachment Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given the transaction commits
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -195,7 +209,7 @@ Feature: Attribute Attachment Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
-    Given the transaction commits
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -218,6 +232,14 @@ Feature: Attribute Attachment Resolution
         $y has $x;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given reasoned session has database name: reasoned
+    Given materialised session has database name: materialised
+    Given session opens transaction of type: write
     Given for each session, graql insert
       """
       insert
@@ -225,12 +247,10 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    Given transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: write
 #    When materialised database is completed
-    Given the transaction commits
-    Given the integrity is validated
+    Given for each session, transaction commits
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -77,8 +77,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -88,7 +86,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -134,8 +132,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -146,7 +142,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -183,8 +179,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -195,7 +189,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -210,8 +204,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
@@ -247,8 +239,6 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -259,7 +249,7 @@ Feature: Attribute Attachment Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -26,7 +26,7 @@ Feature: Attribute Attachment Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql define
       """
       define
@@ -58,7 +58,7 @@ Feature: Attribute Attachment Resolution
       unrelated-attribute sub attribute, value string;
       """
     Given for each session, transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -80,7 +80,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql insert
       """
       insert
@@ -88,18 +88,18 @@ Feature: Attribute Attachment Resolution
       $geY isa person;
       """
     Given for each session, transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has string-attribute $y;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Then for each session, transaction closes
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa string-attribute;
@@ -107,6 +107,8 @@ Feature: Attribute Attachment Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
 #    Then materialised and reasoned databases are the same size
+    Then for each session, transaction closes
+
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -135,7 +137,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql insert
       """
       insert
@@ -144,10 +146,10 @@ Feature: Attribute Attachment Resolution
       (leader:$geX, member:$geX) isa team;
       """
     Given for each session, transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has string-attribute $y;
@@ -155,6 +157,8 @@ Feature: Attribute Attachment Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
 #    Then materialised and reasoned databases are the same size
+    Then for each session, transaction closes
+
 
 
   Scenario: a rule can infer an attribute value that did not previously exist in the graph
@@ -182,7 +186,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql insert
       """
       insert
@@ -191,26 +195,26 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Ocado';
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Then for each session, transaction closes
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer $r;
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
-    Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Then for each session, transaction closes
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has retailer 'Tesco';
@@ -239,7 +243,7 @@ Feature: Attribute Attachment Resolution
       | materialised |
     Given reasoned session has database name: reasoned
     Given materialised session has database name: materialised
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
     Given for each session, graql insert
       """
       insert
@@ -248,14 +252,13 @@ Feature: Attribute Attachment Resolution
       $r "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given session opens transaction of type: write
+    Given session opens transactions with reasoning of type: write
 #    When materialised database is completed
     Given for each session, transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado';
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -59,8 +59,6 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given for each session, graql insert
       """
       insert
@@ -119,8 +117,6 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -135,7 +131,7 @@ Feature: Concept Inequality Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given for each session, transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -155,7 +151,7 @@ Feature: Concept Inequality Resolution
 
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -198,7 +194,7 @@ Feature: Concept Inequality Resolution
 
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -238,7 +234,7 @@ Feature: Concept Inequality Resolution
   y is not z
 
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -286,7 +282,7 @@ Feature: Concept Inequality Resolution
   x is not z
 
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -333,7 +329,7 @@ Feature: Concept Inequality Resolution
   y2 is not  z2
 
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -400,7 +396,7 @@ Feature: Concept Inequality Resolution
   y     - is not - >  z2
 
     Given sessions open transactions of type: write
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -485,8 +481,6 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
       """
@@ -496,7 +490,7 @@ Feature: Concept Inequality Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -566,8 +560,6 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given reasoned session has database name: reasoned
-    Given materialised session has database name: materialised
     Given sessions open transactions of type: write
     Given for each session, graql insert
     """
@@ -579,7 +571,7 @@ Feature: Concept Inequality Resolution
       """
     Given for each session, transaction commits
     Given sessions open transactions of type: write
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -76,7 +76,6 @@ Feature: Concept Inequality Resolution
     Given for each session, transaction commits
 
 
-  # TODO: re-enable all steps when 3-hop transitivity is resolvable
   Scenario: a rule can be applied based on concept inequality
     Given connection close all sessions
     Given connection open schema sessions for databases:
@@ -138,7 +137,7 @@ Feature: Concept Inequality Resolution
       """
       match (related-state: $s) isa holds;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -146,7 +145,7 @@ Feature: Concept Inequality Resolution
       """
       match $s isa state, has name 's2';
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
@@ -158,7 +157,7 @@ Feature: Concept Inequality Resolution
       """
       match (ball1: $x, ball2: $y) isa selection;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     # materialised: [ab, ba, bc, cb]
     # inferred: [aa, ac, bb, ca, cc]
     Given answer size in reasoned database is: 9
@@ -170,7 +169,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y) isa selection;
         not { $x is $y; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # materialised: [ab, ba, bc, cb]
     # inferred: [ac, ca]
     Then answer size in reasoned database is: 6
@@ -187,9 +186,9 @@ Feature: Concept Inequality Resolution
         not { $nx is $ny; };
       get $x, $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
@@ -204,7 +203,7 @@ Feature: Concept Inequality Resolution
         not { $x is $y; };
         $y has name 'c';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -217,9 +216,9 @@ Feature: Concept Inequality Resolution
         $y has name 'c';
         {$x has name 'a';} or {$x has name 'b';};
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: pairs of inferred relations can be filtered by inequality of players in the same role
@@ -244,7 +243,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $z) isa selection;
         not { $y is $z; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # [aab, aac, aba, abc, aca, acb,
     #  bab, bac, bba, bbc, bca, bcb,
     #  cab, cac, cba, cbc, cca, ccb]
@@ -263,9 +262,9 @@ Feature: Concept Inequality Resolution
         not { $ny is $nz; };
       get $x, $y, $z;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 18
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
 
@@ -292,7 +291,7 @@ Feature: Concept Inequality Resolution
         (ball1: $y, ball2: $z) isa selection;
         not { $x is $z; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 18
     # verify that $y and $z always have distinct names
     Then for each session, transaction closes
@@ -308,9 +307,9 @@ Feature: Concept Inequality Resolution
         not { $nx is $nz; };
       get $x, $y, $z;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 18
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inequality predicates can operate independently against multiple pairs of relations in the same query
@@ -340,7 +339,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y2) isa selection;
         (ball1: $x, ball2: $z2) isa selection;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
     Then answer size in reasoned database is: 243
     Then for each session, transaction closes
@@ -356,7 +355,7 @@ Feature: Concept Inequality Resolution
         not { $y1 is $z1; };
         not { $y2 is $z2; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
     Then answer size in reasoned database is: 108
     Then for each session, transaction closes
@@ -379,9 +378,9 @@ Feature: Concept Inequality Resolution
         not { $ny2 is $nz2; };
       get $x, $y1, $z1, $y2, $z2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 108
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inequality predicates can operate independently against multiple roleplayers in the same relation
@@ -406,7 +405,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $z1) isa selection;
         (ball1: $y, ball2: $z2) isa selection;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
     Then answer size in reasoned database is: 81
     Then for each session, transaction closes
@@ -421,7 +420,7 @@ Feature: Concept Inequality Resolution
         not { $x is $z1; };
         not { $y is $z2; };
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
     Then answer size in reasoned database is: 36
     Then for each session, transaction closes
@@ -443,9 +442,9 @@ Feature: Concept Inequality Resolution
         not { $ny is $nz2; };
       get $x, $y, $z1, $z2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 36
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -591,4 +590,4 @@ Feature: Concept Inequality Resolution
     # x      | value | type     |
     # Sprite | Tesco | retailer |
     Then answer size in reasoned database is: 1
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -25,8 +25,8 @@ Feature: Concept Inequality Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -113,7 +113,6 @@ Feature: Concept Inequality Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -122,7 +121,6 @@ Feature: Concept Inequality Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -134,7 +132,6 @@ Feature: Concept Inequality Resolution
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -173,7 +170,6 @@ Feature: Concept Inequality Resolution
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -211,7 +207,6 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -257,7 +252,6 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -302,7 +296,6 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -365,7 +358,6 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -443,7 +435,6 @@ Feature: Concept Inequality Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -512,7 +503,6 @@ Feature: Concept Inequality Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -113,7 +113,7 @@ Feature: Concept Inequality Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (related-state: $s) isa holds;
@@ -121,7 +121,7 @@ Feature: Concept Inequality Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $s isa state, has name 's2';
@@ -132,7 +132,7 @@ Feature: Concept Inequality Resolution
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (ball1: $x, ball2: $y) isa selection;
@@ -170,7 +170,7 @@ Feature: Concept Inequality Resolution
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -207,7 +207,7 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -252,7 +252,7 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -296,7 +296,7 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -358,7 +358,7 @@ Feature: Concept Inequality Resolution
 
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -435,7 +435,7 @@ Feature: Concept Inequality Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -503,7 +503,7 @@ Feature: Concept Inequality Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -27,7 +27,7 @@ Feature: Concept Inequality Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -82,7 +82,7 @@ Feature: Concept Inequality Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -117,7 +117,7 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -130,10 +130,10 @@ Feature: Concept Inequality Resolution
       (related-state: $s2) isa achieved;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (related-state: $s) isa holds;
@@ -141,7 +141,7 @@ Feature: Concept Inequality Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $s isa state, has name 's2';
@@ -150,10 +150,10 @@ Feature: Concept Inequality Resolution
 
 
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (ball1: $x, ball2: $y) isa selection;
@@ -163,7 +163,7 @@ Feature: Concept Inequality Resolution
     # inferred: [aa, ac, bb, ca, cc]
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -175,7 +175,7 @@ Feature: Concept Inequality Resolution
     # inferred: [ac, ca]
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     # verify that the answer pairs to the previous query have distinct names within each pair
     Then for graql query
       """
@@ -193,10 +193,10 @@ Feature: Concept Inequality Resolution
 
 
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -207,7 +207,7 @@ Feature: Concept Inequality Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     # verify answers are [ac, bc]
     Then for graql query
       """
@@ -233,10 +233,10 @@ Feature: Concept Inequality Resolution
   v     v
   y is not z
 
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -250,7 +250,7 @@ Feature: Concept Inequality Resolution
     #  cab, cac, cba, cbc, cca, ccb]
     Then answer size in reasoned database is: 18
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     # verify that $y and $z always have distinct names
     Then for graql query
       """
@@ -281,10 +281,10 @@ Feature: Concept Inequality Resolution
   /     v
   x is not z
 
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -296,7 +296,7 @@ Feature: Concept Inequality Resolution
     Then answer size in reasoned database is: 18
     # verify that $y and $z always have distinct names
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -328,10 +328,10 @@ Feature: Concept Inequality Resolution
   v         v
   y2 is not  z2
 
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -344,7 +344,7 @@ Feature: Concept Inequality Resolution
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
     Then answer size in reasoned database is: 243
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -360,7 +360,7 @@ Feature: Concept Inequality Resolution
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
     Then answer size in reasoned database is: 108
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -395,10 +395,10 @@ Feature: Concept Inequality Resolution
   v
   y     - is not - >  z2
 
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -410,7 +410,7 @@ Feature: Concept Inequality Resolution
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
     Then answer size in reasoned database is: 81
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -425,7 +425,7 @@ Feature: Concept Inequality Resolution
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
     Then answer size in reasoned database is: 36
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -457,7 +457,7 @@ Feature: Concept Inequality Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -481,7 +481,7 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -489,10 +489,10 @@ Feature: Concept Inequality Resolution
       $y isa soft-drink, has name "Tesco";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -522,7 +522,7 @@ Feature: Concept Inequality Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -560,7 +560,7 @@ Feature: Concept Inequality Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
     """
       insert
@@ -570,10 +570,10 @@ Feature: Concept Inequality Resolution
       $z "Ocado" isa retailer;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -112,12 +112,18 @@ Feature: Concept Inequality Resolution
       (related-state: $s2) isa achieved;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (related-state: $s) isa holds;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match $s isa state, has name 's2';
@@ -127,6 +133,9 @@ Feature: Concept Inequality Resolution
 
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (ball1: $x, ball2: $y) isa selection;
@@ -163,6 +172,9 @@ Feature: Concept Inequality Resolution
 
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -198,6 +210,9 @@ Feature: Concept Inequality Resolution
   y is not z
 
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -241,6 +256,9 @@ Feature: Concept Inequality Resolution
   x is not z
 
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -283,6 +301,9 @@ Feature: Concept Inequality Resolution
   y2 is not  z2
 
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -343,6 +364,9 @@ Feature: Concept Inequality Resolution
   y     - is not - >  z2
 
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -418,6 +442,9 @@ Feature: Concept Inequality Resolution
       $y isa soft-drink, has name "Tesco";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -484,6 +511,9 @@ Feature: Concept Inequality Resolution
       $z "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -598,7 +598,7 @@ Feature: Negation Resolution
         not {(superior: $continent, subordinate: $area) isa location-hierarchy;};
       """
     Then answer size in reasoned database is: 0
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: negation can exclude a particular entity from a matched transitive relation
@@ -709,7 +709,7 @@ Feature: Negation Resolution
       """
       match $x has name "Not Ten", has age 20;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for graql query
       """
@@ -983,7 +983,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 0
     Then answers are consistent across 5 executions in reasoned database
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (currently takes too long) (#75)
@@ -1058,7 +1058,7 @@ Feature: Negation Resolution
       """
       match (role-3: $x, role-4: $y) isa relation-4;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
     Then answers are consistent across 5 executions in reasoned database
     Then materialised and reasoned databases are the same size

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -192,7 +192,7 @@ Feature: Negation Resolution
         not {$y 20;};
       """
     Then answer size in reasoned database is: 1
-    Then     answer set is equivalent for graql query
+    Then answer set is equivalent for graql query
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
       """
@@ -218,7 +218,7 @@ Feature: Negation Resolution
         not {$y isa name;};
       """
     Then answer size in reasoned database is: 2
-    Then     answer set is equivalent for graql query
+    Then answer set is equivalent for graql query
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
       """

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -24,8 +24,8 @@ Feature: Negation Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -194,7 +194,6 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 1
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
       """
       match
@@ -221,7 +220,6 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 2
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
       """
       match $x has age $y;
@@ -272,7 +270,6 @@ Feature: Negation Resolution
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -327,7 +324,6 @@ Feature: Negation Resolution
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -393,7 +389,6 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -587,7 +582,6 @@ Feature: Negation Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -674,7 +668,6 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -711,7 +704,6 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -749,7 +741,6 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -803,7 +794,6 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -819,7 +809,6 @@ Feature: Negation Resolution
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -887,7 +876,6 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -988,7 +976,6 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1066,7 +1053,6 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1154,7 +1140,6 @@ Feature: Negation Resolution
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -193,8 +193,8 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 1
     Then     answer set is equivalent for graql query
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
       """
       match
         $x has age $y;
@@ -219,8 +219,8 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Then     answer set is equivalent for graql query
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
       """
       match $x has age $y;
       """
@@ -269,8 +269,8 @@ Feature: Negation Resolution
       """
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -323,8 +323,8 @@ Feature: Negation Resolution
       """
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -388,8 +388,8 @@ Feature: Negation Resolution
         };
       """
     Then answer size in reasoned database is: 6
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -581,8 +581,8 @@ Feature: Negation Resolution
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -667,8 +667,8 @@ Feature: Negation Resolution
         $x has index "aa";
       """
     Then answer size in reasoned database is: 2
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -703,8 +703,8 @@ Feature: Negation Resolution
       $y isa person, has age 20;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 20;
@@ -740,8 +740,8 @@ Feature: Negation Resolution
       $z isa person;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa person;
@@ -793,8 +793,8 @@ Feature: Negation Resolution
       (company-with-country: $c, country-for-company: $f) isa company-country;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa company;
@@ -808,8 +808,8 @@ Feature: Negation Resolution
       """
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -875,8 +875,8 @@ Feature: Negation Resolution
         };
       """
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -975,8 +975,8 @@ Feature: Negation Resolution
       (identified-fault: $f2, identifying-question: $q2) isa fault-identification;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
@@ -1052,8 +1052,8 @@ Feature: Negation Resolution
       (symmetric-role: $c, symmetric-role: $b ) isa symmetric-relation;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (role-3: $x, role-4: $y) isa relation-4;
@@ -1139,8 +1139,8 @@ Feature: Negation Resolution
       """
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -24,8 +24,8 @@ Feature: Negation Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -580,7 +580,7 @@ Feature: Negation Resolution
       (superior: $cntry, subordinate: $cit) isa location-hierarchy;
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -702,7 +702,7 @@ Feature: Negation Resolution
       $x isa person, has age 10;
       $y isa person, has age 20;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -739,7 +739,7 @@ Feature: Negation Resolution
       $y isa person, has age 20;
       $z isa person;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -792,7 +792,7 @@ Feature: Negation Resolution
       (company-with-country: $b, country-for-company: $e) isa company-country;
       (company-with-country: $c, country-for-company: $f) isa company-country;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -974,7 +974,7 @@ Feature: Negation Resolution
       (identified-fault: $f1, identifying-question: $q1) isa fault-identification;
       (identified-fault: $f2, identifying-question: $q2) isa fault-identification;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1051,7 +1051,7 @@ Feature: Negation Resolution
 
       (symmetric-role: $c, symmetric-role: $b ) isa symmetric-relation;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1130,7 +1130,7 @@ Feature: Negation Resolution
       (link-from: $ee, link-to: $ff) isa link;
       (link-from: $ff, link-to: $gg) isa link;
       """
-    # When materialised database is completed
+    # Then materialised database is completed
     Then for graql query
       """
       match

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -194,7 +194,7 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 1
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
       """
       match
         $x has age $y;
@@ -220,7 +220,7 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 2
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
       """
       match $x has age $y;
       """
@@ -270,7 +270,7 @@ Feature: Negation Resolution
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -324,7 +324,7 @@ Feature: Negation Resolution
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -389,7 +389,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -582,7 +582,7 @@ Feature: Negation Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -668,7 +668,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -704,7 +704,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 20;
@@ -741,7 +741,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa person;
@@ -794,7 +794,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa company;
@@ -809,7 +809,7 @@ Feature: Negation Resolution
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -876,7 +876,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -976,7 +976,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
@@ -1053,7 +1053,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (role-3: $x, role-4: $y) isa relation-4;
@@ -1140,7 +1140,7 @@ Feature: Negation Resolution
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -192,7 +192,10 @@ Feature: Negation Resolution
         not {$y 20;};
       """
     Then answer size in reasoned database is: 1
-    Then answer set is equivalent for graql query
+    Then     answer set is equivalent for graql query
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
       """
       match
         $x has age $y;
@@ -216,7 +219,10 @@ Feature: Negation Resolution
         not {$y isa name;};
       """
     Then answer size in reasoned database is: 2
-    Then answer set is equivalent for graql query
+    Then     answer set is equivalent for graql query
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
       """
       match $x has age $y;
       """
@@ -265,6 +271,9 @@ Feature: Negation Resolution
       """
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -317,6 +326,9 @@ Feature: Negation Resolution
       """
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -380,6 +392,9 @@ Feature: Negation Resolution
         };
       """
     Then answer size in reasoned database is: 6
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -571,6 +586,9 @@ Feature: Negation Resolution
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -655,6 +673,9 @@ Feature: Negation Resolution
         $x has index "aa";
       """
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -689,6 +710,9 @@ Feature: Negation Resolution
       $y isa person, has age 20;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 20;
@@ -724,6 +748,9 @@ Feature: Negation Resolution
       $z isa person;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa person;
@@ -775,6 +802,9 @@ Feature: Negation Resolution
       (company-with-country: $c, country-for-company: $f) isa company-country;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa company;
@@ -788,6 +818,9 @@ Feature: Negation Resolution
       """
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -853,6 +886,9 @@ Feature: Negation Resolution
         };
       """
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -951,6 +987,9 @@ Feature: Negation Resolution
       (identified-fault: $f2, identifying-question: $q2) isa fault-identification;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
@@ -1026,6 +1065,9 @@ Feature: Negation Resolution
       (symmetric-role: $c, symmetric-role: $b ) isa symmetric-relation;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (role-3: $x, role-4: $y) isa relation-4;
@@ -1111,6 +1153,9 @@ Feature: Negation Resolution
       """
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -194,7 +194,7 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 1
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
       """
       match
         $x has age $y;
@@ -220,7 +220,7 @@ Feature: Negation Resolution
     Then answer size in reasoned database is: 2
     Then     answer set is equivalent for graql query
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
       """
       match $x has age $y;
       """
@@ -270,7 +270,7 @@ Feature: Negation Resolution
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -324,7 +324,7 @@ Feature: Negation Resolution
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -389,7 +389,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -582,7 +582,7 @@ Feature: Negation Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -668,7 +668,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -704,7 +704,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 20;
@@ -741,7 +741,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa person;
@@ -794,7 +794,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa company;
@@ -809,7 +809,7 @@ Feature: Negation Resolution
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -876,7 +876,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -976,7 +976,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
@@ -1053,7 +1053,7 @@ Feature: Negation Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (role-3: $x, role-4: $y) isa relation-4;
@@ -1140,7 +1140,7 @@ Feature: Negation Resolution
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -108,7 +108,7 @@ Feature: Recursion Resolution
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then materialised and reasoned databases are the same size
 
@@ -180,7 +180,7 @@ Feature: Recursion Resolution
       """
       match (role31: $x, role32: $y) isa relation3;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then materialised and reasoned databases are the same size
 
@@ -292,9 +292,9 @@ Feature: Recursion Resolution
       """
       match $x isa dream; limit 10;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when materialisation is possible (may be an infinite graph?) (#75)
@@ -391,15 +391,15 @@ Feature: Recursion Resolution
       """
       match $p isa pair, has name 'ff';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 16
     Then for graql query
       """
       match $p isa pair;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 64
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -494,7 +494,7 @@ Feature: Recursion Resolution
         $x has index 'i';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -505,7 +505,7 @@ Feature: Recursion Resolution
         {$ind = 'j';} or {$ind = 's';} or {$ind = 'v';};
       get $y;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -573,7 +573,7 @@ Feature: Recursion Resolution
         $Y has name $name;
       get $Y, $name;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -591,7 +591,7 @@ Feature: Recursion Resolution
         $X has name 'aa';
       get $Y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -606,7 +606,7 @@ Feature: Recursion Resolution
       """
       match (ancestor: $X, descendant: $Y) isa Ancestor;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -626,7 +626,7 @@ Feature: Recursion Resolution
       """
       match ($X, $Y) isa Ancestor;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -719,7 +719,7 @@ Feature: Recursion Resolution
         $Y has name $name;
       get $Y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -744,7 +744,7 @@ Feature: Recursion Resolution
         $Y has name 'd';
       get $X;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -837,7 +837,7 @@ Feature: Recursion Resolution
         $x has name 'a';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -848,7 +848,7 @@ Feature: Recursion Resolution
         {$name = 'f';} or {$name = 'a';};
       get $y;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable ('all answers correct' takes too long, 'same size' test fails) (#75)
@@ -916,7 +916,7 @@ Feature: Recursion Resolution
         $y has index 'a';
       get $x;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -924,7 +924,7 @@ Feature: Recursion Resolution
       """
       match $x has index 'a2';
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -1010,7 +1010,7 @@ Feature: Recursion Resolution
       """
       match (from: $x, to: $y) isa reachable;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1092,7 +1092,7 @@ Feature: Recursion Resolution
         $x has index 'a';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1103,7 +1103,7 @@ Feature: Recursion Resolution
         {$indY = 'a';} or {$indY = 'b';} or {$indY = 'c';} or {$indY = 'd';};
       get $y;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -1173,7 +1173,7 @@ Feature: Recursion Resolution
         $x has name 'ann';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1184,7 +1184,7 @@ Feature: Recursion Resolution
         {$name = 'ann';} or {$name = 'bill';} or {$name = 'peter';};
       get $y;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -1281,7 +1281,7 @@ Feature: Recursion Resolution
         $x has name 'a';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1296,7 +1296,7 @@ Feature: Recursion Resolution
       """
       match (RSG-from: $x, RSG-to: $y) isa RevSG;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1313,7 +1313,7 @@ Feature: Recursion Resolution
         {$nameX = 'f';$nameY = 'k';};
       get $x, $y;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -1479,7 +1479,7 @@ Feature: Recursion Resolution
         $x has index 'a0';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1487,7 +1487,7 @@ Feature: Recursion Resolution
       """
       match { $y isa a-entity; } or { $y isa end; };
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
@@ -1685,7 +1685,7 @@ Feature: Recursion Resolution
         $x has index 'a0';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1693,7 +1693,7 @@ Feature: Recursion Resolution
       """
       match $y isa b-entity;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
   # TODO: re-enable all steps when resolvable (currently takes too long) (#75)
   Scenario: linear transitivity matrix test
@@ -1839,7 +1839,7 @@ Feature: Recursion Resolution
         $x has index 'a';
       get $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
     Given for each session, transaction commits
     Given for each session, open transactions with reasoning of type: read
@@ -1847,4 +1847,4 @@ Feature: Recursion Resolution
       """
       match $y isa a-entity;
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -102,6 +102,9 @@ Feature: Recursion Resolution
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy;
@@ -172,6 +175,9 @@ Feature: Recursion Resolution
       (role11:$w, role12:$q) isa relation1;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -235,6 +241,9 @@ Feature: Recursion Resolution
       (role11:$x, role12:$y) isa relation1;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -280,6 +289,9 @@ Feature: Recursion Resolution
       (dreamer: $x, dream-subject: $x) isa dream;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa dream; limit 10;
@@ -377,6 +389,9 @@ Feature: Recursion Resolution
       (supertype: $f, subtype: $rr2) isa inheritance;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $p isa pair, has name 'ff';
@@ -475,6 +490,9 @@ Feature: Recursion Resolution
       (role-A: $u, role-B: $v) isa H;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -484,6 +502,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -549,6 +570,9 @@ Feature: Recursion Resolution
       (parent: $c, child: $ca) isa Parent;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -559,6 +583,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -575,6 +602,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -588,6 +618,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -606,6 +639,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -685,6 +721,9 @@ Feature: Recursion Resolution
       (friend: $c, friend: $d) isa Friend;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -695,6 +734,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -718,6 +760,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -798,6 +843,9 @@ Feature: Recursion Resolution
       (parent: $h, child: $g) isa Parent;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -807,6 +855,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -873,6 +924,9 @@ Feature: Recursion Resolution
       (P-roleA: $a2, P-roleB: $a1) isa P;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -882,6 +936,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match $x has index 'a2';
@@ -966,12 +1023,18 @@ Feature: Recursion Resolution
       (from: $cc, to: $dd) isa link;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa reachable;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1041,6 +1104,9 @@ Feature: Recursion Resolution
       (coordinate: $c, coordinate: $d) isa link;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1050,6 +1116,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1118,6 +1187,9 @@ Feature: Recursion Resolution
       (parent: $john, child: $bill) isa Parent;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1127,6 +1199,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1222,6 +1297,9 @@ Feature: Recursion Resolution
       (down-from: $p, down-to: $k) isa down;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1231,6 +1309,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1244,6 +1325,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1414,6 +1498,9 @@ Feature: Recursion Resolution
       (R2-from: $b35, R2-to: $b45) isa R2;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1423,6 +1510,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match { $y isa a-entity; } or { $y isa end; };
@@ -1616,6 +1706,9 @@ Feature: Recursion Resolution
       (Q-from: $b5_10, Q-to: $b6_10) isa Q;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1625,6 +1718,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa b-entity;
@@ -1766,6 +1862,9 @@ Feature: Recursion Resolution
       (Q-from: $a5_4, Q-to: $a5_5) isa Q;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -1775,6 +1874,9 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa a-entity;

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -27,8 +27,8 @@ Feature: Recursion Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -101,7 +101,7 @@ Feature: Recursion Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -173,7 +173,7 @@ Feature: Recursion Resolution
       (role21:$v, role22:$w) isa relation2;
       (role11:$w, role12:$q) isa relation1;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -238,7 +238,7 @@ Feature: Recursion Resolution
       (role11:$x, role12:$x) isa relation1;
       (role11:$x, role12:$y) isa relation1;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -285,7 +285,7 @@ Feature: Recursion Resolution
       # If only Yusuf didn't dream about himself...
       (dreamer: $x, dream-subject: $x) isa dream;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -384,7 +384,7 @@ Feature: Recursion Resolution
       (supertype: $f, subtype: $rr) isa inheritance;
       (supertype: $f, subtype: $rr2) isa inheritance;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -484,7 +484,7 @@ Feature: Recursion Resolution
       (role-A: $r, role-B: $s) isa H;
       (role-A: $u, role-B: $v) isa H;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -562,7 +562,7 @@ Feature: Recursion Resolution
       (parent: $aaa, child: $aaaa) isa Parent;
       (parent: $c, child: $ca) isa Parent;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -708,7 +708,7 @@ Feature: Recursion Resolution
       (friend: $a, friend: $g) isa Friend;
       (friend: $c, friend: $d) isa Friend;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -827,7 +827,7 @@ Feature: Recursion Resolution
 
       (parent: $h, child: $g) isa Parent;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -906,7 +906,7 @@ Feature: Recursion Resolution
       (P-roleA: $a1, P-roleB: $a) isa P;
       (P-roleA: $a2, P-roleB: $a1) isa P;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1003,7 +1003,7 @@ Feature: Recursion Resolution
       (from: $cc, to: $cc) isa link;
       (from: $cc, to: $dd) isa link;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1082,7 +1082,7 @@ Feature: Recursion Resolution
       (coordinate: $c, coordinate: $c) isa link;
       (coordinate: $c, coordinate: $d) isa link;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1163,7 +1163,7 @@ Feature: Recursion Resolution
       (parent: $john, child: $peter) isa Parent;
       (parent: $john, child: $bill) isa Parent;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1271,7 +1271,7 @@ Feature: Recursion Resolution
       (down-from: $i, down-to: $d) isa down;
       (down-from: $p, down-to: $k) isa down;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1469,7 +1469,7 @@ Feature: Recursion Resolution
       (R2-from: $b25, R2-to: $b35) isa R2;
       (R2-from: $b35, R2-to: $b45) isa R2;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1675,7 +1675,7 @@ Feature: Recursion Resolution
       (Q-from: $b4_10, Q-to: $b5_10) isa Q;
       (Q-from: $b5_10, Q-to: $b6_10) isa Q;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1829,7 +1829,7 @@ Feature: Recursion Resolution
       (Q-from: $a5_3, Q-to: $a5_4) isa Q;
       (Q-from: $a5_4, Q-to: $a5_5) isa Q;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -102,8 +102,8 @@ Feature: Recursion Resolution
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy;
@@ -174,8 +174,8 @@ Feature: Recursion Resolution
       (role11:$w, role12:$q) isa relation1;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -239,8 +239,8 @@ Feature: Recursion Resolution
       (role11:$x, role12:$y) isa relation1;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -286,8 +286,8 @@ Feature: Recursion Resolution
       (dreamer: $x, dream-subject: $x) isa dream;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa dream; limit 10;
@@ -385,8 +385,8 @@ Feature: Recursion Resolution
       (supertype: $f, subtype: $rr2) isa inheritance;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $p isa pair, has name 'ff';
@@ -485,8 +485,8 @@ Feature: Recursion Resolution
       (role-A: $u, role-B: $v) isa H;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -496,8 +496,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -563,8 +563,8 @@ Feature: Recursion Resolution
       (parent: $c, child: $ca) isa Parent;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -575,8 +575,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -593,8 +593,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -608,8 +608,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -628,8 +628,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -709,8 +709,8 @@ Feature: Recursion Resolution
       (friend: $c, friend: $d) isa Friend;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -721,8 +721,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -746,8 +746,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -828,8 +828,8 @@ Feature: Recursion Resolution
       (parent: $h, child: $g) isa Parent;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -839,8 +839,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -907,8 +907,8 @@ Feature: Recursion Resolution
       (P-roleA: $a2, P-roleB: $a1) isa P;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -918,8 +918,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $x has index 'a2';
@@ -1004,16 +1004,16 @@ Feature: Recursion Resolution
       (from: $cc, to: $dd) isa link;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa reachable;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1083,8 +1083,8 @@ Feature: Recursion Resolution
       (coordinate: $c, coordinate: $d) isa link;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1094,8 +1094,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1164,8 +1164,8 @@ Feature: Recursion Resolution
       (parent: $john, child: $bill) isa Parent;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1175,8 +1175,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1272,8 +1272,8 @@ Feature: Recursion Resolution
       (down-from: $p, down-to: $k) isa down;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1283,8 +1283,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1298,8 +1298,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1470,8 +1470,8 @@ Feature: Recursion Resolution
       (R2-from: $b35, R2-to: $b45) isa R2;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1481,8 +1481,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match { $y isa a-entity; } or { $y isa end; };
@@ -1676,8 +1676,8 @@ Feature: Recursion Resolution
       (Q-from: $b5_10, Q-to: $b6_10) isa Q;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1687,8 +1687,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa b-entity;
@@ -1830,8 +1830,8 @@ Feature: Recursion Resolution
       (Q-from: $a5_4, Q-to: $a5_5) isa Q;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1841,8 +1841,8 @@ Feature: Recursion Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa a-entity;

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -103,7 +103,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy;
@@ -175,7 +175,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -240,7 +240,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -287,7 +287,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa dream; limit 10;
@@ -386,7 +386,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $p isa pair, has name 'ff';
@@ -486,7 +486,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -497,7 +497,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -564,7 +564,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -576,7 +576,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -594,7 +594,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -609,7 +609,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -629,7 +629,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -710,7 +710,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -722,7 +722,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -747,7 +747,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -829,7 +829,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -840,7 +840,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -908,7 +908,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -919,7 +919,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $x has index 'a2';
@@ -1005,7 +1005,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa reachable;
@@ -1013,7 +1013,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1084,7 +1084,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1095,7 +1095,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1165,7 +1165,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1176,7 +1176,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1273,7 +1273,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1284,7 +1284,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1299,7 +1299,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1471,7 +1471,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1482,7 +1482,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match { $y isa a-entity; } or { $y isa end; };
@@ -1677,7 +1677,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1688,7 +1688,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa b-entity;
@@ -1831,7 +1831,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1842,7 +1842,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa a-entity;

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -27,8 +27,8 @@ Feature: Recursion Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -103,7 +103,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -176,7 +175,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -242,7 +240,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -290,7 +287,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -390,7 +386,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -491,7 +486,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -503,7 +497,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -571,7 +564,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -584,7 +576,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -603,7 +594,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -619,7 +609,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -640,7 +629,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -722,7 +710,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -735,7 +722,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -761,7 +747,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -844,7 +829,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -856,7 +840,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -925,7 +908,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -937,7 +919,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1024,7 +1005,6 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1033,7 +1013,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1105,7 +1084,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1117,7 +1095,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1188,7 +1165,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1200,7 +1176,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1298,7 +1273,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1310,7 +1284,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1326,7 +1299,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1499,7 +1471,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1511,7 +1482,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1707,7 +1677,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1719,7 +1688,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -1863,7 +1831,6 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1875,7 +1842,6 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -103,7 +103,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy;
@@ -175,7 +175,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -240,7 +240,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -287,7 +287,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa dream; limit 10;
@@ -386,7 +386,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $p isa pair, has name 'ff';
@@ -486,7 +486,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -497,7 +497,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -564,7 +564,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -576,7 +576,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -594,7 +594,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -609,7 +609,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -629,7 +629,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -710,7 +710,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -722,7 +722,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -747,7 +747,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -829,7 +829,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -840,7 +840,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -908,7 +908,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -919,7 +919,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $x has index 'a2';
@@ -1005,7 +1005,7 @@ Feature: Recursion Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa reachable;
@@ -1013,7 +1013,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1084,7 +1084,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1095,7 +1095,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1165,7 +1165,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1176,7 +1176,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1273,7 +1273,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1284,7 +1284,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1299,7 +1299,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 11
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1471,7 +1471,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1482,7 +1482,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match { $y isa a-entity; } or { $y isa end; };
@@ -1677,7 +1677,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1688,7 +1688,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa b-entity;
@@ -1831,7 +1831,7 @@ Feature: Recursion Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1842,7 +1842,7 @@ Feature: Recursion Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa a-entity;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -508,7 +508,7 @@ Feature: Relation Inference Resolution
       """
       match (coworker: $x, coworker: $x) isa coworkers;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # (p,p) is a coworkers since people work with themselves.
     # Applying the robot work rule we see that (r1,p) is a pet ownership, and (p,p) and (p,r2) are coworker relations,
     # so (r1,p) and (r1,r2) are both coworker relations.
@@ -522,7 +522,7 @@ Feature: Relation Inference Resolution
       """
       match (coworker: $x, coworker: $y) isa coworkers;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # $x | $y |
     # p  | p  |
     # p  | r2 |
@@ -619,10 +619,10 @@ Feature: Relation Inference Resolution
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Then answers are consistent across 5 executions in reasoned database
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a transitive rule's 'then' matches a query, but its 'when' is unmet, the material answers are returned
@@ -866,7 +866,7 @@ Feature: Relation Inference Resolution
         $x has name $n;
         $y has name $n;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # (a,a), (b,b), (c,c)
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
@@ -880,7 +880,7 @@ Feature: Relation Inference Resolution
         $n = 'a';
       get $x, $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -891,7 +891,7 @@ Feature: Relation Inference Resolution
         $x has name 'a';
         $y has name 'a';
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   #######################
@@ -939,7 +939,7 @@ Feature: Relation Inference Resolution
         $b isa place, has name "Turku";
         ($b, $c);
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # $c in {'Turku Airport', 'Finland'}
     Then answer size in reasoned database is: 2
     Then materialised and reasoned databases are the same size
@@ -985,7 +985,7 @@ Feature: Relation Inference Resolution
         ($a, $b);
         $b isa place, has name "Turku";
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 1
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -997,7 +997,7 @@ Feature: Relation Inference Resolution
         $b isa place, has name "Turku";
         ($c, $d);
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # (2 db relations + 1 inferred) x 2 for variable swap
     Then answer size in reasoned database is: 6
     Then materialised and reasoned databases are the same size
@@ -1051,7 +1051,7 @@ Feature: Relation Inference Resolution
       """
       match ($a, $b) isa relation;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Despite there being more inferred relations, the answer size is still 6 (as in the previous scenario)
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
@@ -1061,7 +1061,7 @@ Feature: Relation Inference Resolution
       """
       match ($a, $b);
       """
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -1103,7 +1103,7 @@ Feature: Relation Inference Resolution
         ($a, $b);
         ($b, $c);
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # a   | b   | c   |
     # AIR | TUR | FIN |
     # AIR | FIN | TUR |
@@ -1121,7 +1121,6 @@ Feature: Relation Inference Resolution
     Then materialised and reasoned databases are the same size
 
 
-# TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: a relation can be inferred based on a direct type
     Given for each session, graql define
       """
@@ -1181,7 +1180,7 @@ Feature: Relation Inference Resolution
       """
       match ($x) isa derivedRelation;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -1189,7 +1188,7 @@ Feature: Relation Inference Resolution
       """
       match ($x) isa! derivedRelation;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
     Given for each session, open transactions with reasoning of type: read
@@ -1197,6 +1196,6 @@ Feature: Relation Inference Resolution
       """
       match ($x) isa directDerivedRelation;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -24,8 +24,8 @@ Feature: Relation Inference Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -83,7 +83,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -121,7 +120,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -163,7 +161,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -202,7 +199,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -242,7 +238,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -279,7 +274,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -311,7 +305,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -340,7 +333,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -371,7 +363,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -433,7 +424,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -491,7 +481,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -528,7 +517,6 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -592,7 +580,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -626,7 +613,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -655,7 +641,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -687,7 +672,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -696,7 +680,6 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -738,7 +721,6 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -762,7 +744,6 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -802,7 +783,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -842,7 +822,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -902,7 +881,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -913,7 +891,6 @@ Feature: Relation Inference Resolution
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
@@ -946,7 +923,6 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -1019,7 +995,6 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -19,13 +19,14 @@
 Feature: Relation Inference Resolution
 
   Background: Set up databases for resolution testing
-
     Given connection has been opened
-    Given connection open sessions for databases:
-      | materialised |
+    Given connection does not have any database
+    Given connection create database: reasoned
+    Given connection create database: materialised
+    Given connection open schema sessions for databases:
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -57,7 +58,9 @@ Feature: Relation Inference Resolution
 
       name sub attribute, value string;
       """
-
+    Given for each session, transaction commits
+    # each scenario specialises the schema further
+    Given sessions open transactions of type: write
 
   #######################
   # BASIC FUNCTIONALITY #
@@ -74,6 +77,12 @@ Feature: Relation Inference Resolution
         (employee: $p) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -81,7 +90,9 @@ Feature: Relation Inference Resolution
       $y isa dog;
       $z isa person;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -92,6 +103,8 @@ Feature: Relation Inference Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -112,13 +125,21 @@ Feature: Relation Inference Resolution
         (employee: $p) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $x isa person, has name "Haikal";
       $y isa person, has name "Michael";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -129,6 +150,8 @@ Feature: Relation Inference Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -153,13 +176,21 @@ Feature: Relation Inference Resolution
         (item: $x, price: $y) isa item-listing;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $x isa item, has name "3kg jar of Nutella";
       $y 14.99 isa price;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -189,6 +220,12 @@ Feature: Relation Inference Resolution
         (employee: $p, employer: $x, favourite-year: $y) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -197,7 +234,9 @@ Feature: Relation Inference Resolution
       $p2 isa person, has name "Prasanth";
       $y 1664 isa year;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -227,6 +266,12 @@ Feature: Relation Inference Resolution
         (friend: $x, friend: $y) isa friendship;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -236,7 +281,9 @@ Feature: Relation Inference Resolution
       $d isa person, has name "Damien";
       $e isa person, has name "Eustace";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -263,6 +310,12 @@ Feature: Relation Inference Resolution
         (friend: $x, friend: $y) isa friendship;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -272,7 +325,9 @@ Feature: Relation Inference Resolution
       $d isa person, has name "Damien";
       $e isa person, has name "Eustace";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -296,6 +351,12 @@ Feature: Relation Inference Resolution
         (employee: $x, employer: $x) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -303,7 +364,9 @@ Feature: Relation Inference Resolution
       $g isa person, has name "Gawain";
       $h isa person, has name "Hattie";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -326,12 +389,20 @@ Feature: Relation Inference Resolution
         (employee: $x, employer: $x) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $i isa person, has name "Irma";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -355,13 +426,21 @@ Feature: Relation Inference Resolution
         (employee: $y, employer: $x) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $r isa person, has name "Robert";
       $j isa person, has name "Jane";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -413,6 +492,12 @@ Feature: Relation Inference Resolution
           (coworker: $c, coworker: $op) isa coworkers;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -422,7 +507,9 @@ Feature: Relation Inference Resolution
       (pet: $a, owner: $b) isa robot-pet-ownership;
       (coworker: $b, coworker: $c) isa coworkers;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -437,6 +524,8 @@ Feature: Relation Inference Resolution
     # Applying the robot work rule a 2nd time, (r1,p) is a pet ownership and (p,r1) are coworkers,
     # therefore (r1,r1) is a reflexive coworker relation. So the answers are [p] and [r1].
     Then answer size in reasoned database is: 2
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $y) isa coworkers;
@@ -470,6 +559,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -479,7 +574,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x, superior: $y) isa location-hierarchy;
       (subordinate: $y, superior: $y) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -503,6 +600,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -515,7 +618,9 @@ Feature: Relation Inference Resolution
       (subordinate: $b, superior: $c) isa location-hierarchy;
       (subordinate: $c, superior: $d) isa location-hierarchy;
       """
-#    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -558,6 +663,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -578,7 +689,9 @@ Feature: Relation Inference Resolution
 
       (subordinate: $x3, superior: $x4) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -605,13 +718,21 @@ Feature: Relation Inference Resolution
         (employee: $p, employer: $c) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $x isa person;
       $c isa company;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -633,13 +754,21 @@ Feature: Relation Inference Resolution
         (employee: $p, employer: $c) isa employment;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $x isa person;
       $c isa company;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -663,6 +792,12 @@ Feature: Relation Inference Resolution
         (friend: $a, friend: $b, friend: $c) isa friendship;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -670,7 +805,9 @@ Feature: Relation Inference Resolution
       $y isa person, has name "Bob";
       $z isa person, has name "Charlie";
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -679,7 +816,7 @@ Feature: Relation Inference Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
-    Given the transaction commits
+    Then for each session, transaction closes
     Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
@@ -709,6 +846,12 @@ Feature: Relation Inference Resolution
         (choice1: $x, choice2: $z) isa selection;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -719,7 +862,9 @@ Feature: Relation Inference Resolution
       (choice1: $x, choice2: $y) isa selection;
       (choice1: $y, choice2: $z) isa selection;
       """
-#    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -732,6 +877,8 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     # (a,a), (b,b), (c,c)
     Then answer size in reasoned database is: 3
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -743,7 +890,7 @@ Feature: Relation Inference Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
-    Given the transaction commits
+    Then for each session, transaction closes
     Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
@@ -771,6 +918,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -781,7 +934,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x, superior: $y) isa location-hierarchy;
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -810,6 +965,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -820,7 +981,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x, superior: $y) isa location-hierarchy;
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -832,6 +995,8 @@ Feature: Relation Inference Resolution
       """
 #    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 1
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -869,6 +1034,12 @@ Feature: Relation Inference Resolution
         (loc-sub: $x, loc-sup: $y) isa loc-hie;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -879,7 +1050,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x, superior: $y) isa location-hierarchy;
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -890,7 +1063,7 @@ Feature: Relation Inference Resolution
     # Despite there being more inferred relations, the answer size is still 6 (as in the previous scenario)
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
-    Given the transaction commits
+    Then for each session, transaction closes
     Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
@@ -911,6 +1084,12 @@ Feature: Relation Inference Resolution
         (subordinate: $x, superior: $z) isa location-hierarchy;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -921,7 +1100,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x, superior: $y) isa location-hierarchy;
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
-    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -982,6 +1163,12 @@ Feature: Relation Inference Resolution
           (derivedRelationRole: $x) isa directDerivedRelation;
       };
       """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given sessions open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -993,7 +1180,9 @@ Feature: Relation Inference Resolution
       (baseRole: $y) isa subRelation;
       (baseRole: $z) isa subSubRelation;
       """
-#    When materialised database is completed
+    Given for each session, transaction commits
+    Given sessions open transactions of type: write
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -1002,12 +1191,16 @@ Feature: Relation Inference Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa! derivedRelation;
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
+    Then for each session, transaction closes
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa directDerivedRelation;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -26,7 +26,7 @@ Feature: Relation Inference Resolution
     Given connection open schema sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql define
       """
       define
@@ -60,7 +60,7 @@ Feature: Relation Inference Resolution
       """
     Given for each session, transaction commits
     # each scenario specialises the schema further
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
 
   #######################
   # BASIC FUNCTIONALITY #
@@ -82,7 +82,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -91,10 +91,10 @@ Feature: Relation Inference Resolution
       $z isa person;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -104,15 +104,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
-    Then for graql query
-      """
-      match
-        $x isa dog;
-        ($x) isa employment;
-      """
-    Then answer size in reasoned database is: 0
-    Then materialised and reasoned databases are the same size
+    Given for each session, open transactions with reasoning of type: read
 
 
   Scenario: a relation can be inferred based on an attribute ownership
@@ -130,7 +122,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -138,10 +130,10 @@ Feature: Relation Inference Resolution
       $y isa person, has name "Michael";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -151,7 +143,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -181,7 +173,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -189,10 +181,10 @@ Feature: Relation Inference Resolution
       $y 14.99 isa price;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -225,7 +217,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -235,10 +227,10 @@ Feature: Relation Inference Resolution
       $y 1664 isa year;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -271,7 +263,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -282,10 +274,10 @@ Feature: Relation Inference Resolution
       $e isa person, has name "Eustace";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $r isa friendship;
@@ -315,7 +307,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -326,10 +318,10 @@ Feature: Relation Inference Resolution
       $e isa person, has name "Eustace";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x, $y) isa friendship;
@@ -356,7 +348,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -365,10 +357,10 @@ Feature: Relation Inference Resolution
       $h isa person, has name "Hattie";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -394,17 +386,17 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
       $i isa person, has name "Irma";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -431,7 +423,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -439,10 +431,10 @@ Feature: Relation Inference Resolution
       $j isa person, has name "Jane";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -497,7 +489,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -508,10 +500,10 @@ Feature: Relation Inference Resolution
       (coworker: $b, coworker: $c) isa coworkers;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $x) isa coworkers;
@@ -525,7 +517,7 @@ Feature: Relation Inference Resolution
     # therefore (r1,r1) is a reflexive coworker relation. So the answers are [p] and [r1].
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $y) isa coworkers;
@@ -564,7 +556,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -575,10 +567,10 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $y) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa location-hierarchy;
@@ -605,7 +597,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -619,10 +611,10 @@ Feature: Relation Inference Resolution
       (subordinate: $c, superior: $d) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
@@ -668,7 +660,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -690,10 +682,10 @@ Feature: Relation Inference Resolution
       (subordinate: $x3, superior: $x4) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
@@ -723,7 +715,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -731,10 +723,10 @@ Feature: Relation Inference Resolution
       $c isa company;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment;
@@ -759,7 +751,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -767,10 +759,10 @@ Feature: Relation Inference Resolution
       $c isa company;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x) isa employment;
@@ -797,7 +789,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -806,10 +798,10 @@ Feature: Relation Inference Resolution
       $z isa person, has name "Charlie";
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
@@ -817,7 +809,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -851,7 +843,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -863,10 +855,10 @@ Feature: Relation Inference Resolution
       (choice1: $y, choice2: $z) isa selection;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -878,7 +870,7 @@ Feature: Relation Inference Resolution
     # (a,a), (b,b), (c,c)
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -891,7 +883,7 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -923,7 +915,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -935,10 +927,10 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -970,7 +962,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -982,10 +974,10 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -996,7 +988,7 @@ Feature: Relation Inference Resolution
 #    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1039,7 +1031,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -1051,10 +1043,10 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match ($a, $b) isa relation;
@@ -1064,7 +1056,7 @@ Feature: Relation Inference Resolution
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match ($a, $b);
@@ -1089,7 +1081,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -1101,10 +1093,10 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -1168,7 +1160,7 @@ Feature: Relation Inference Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Given for each session, graql insert
       """
       insert
@@ -1181,10 +1173,10 @@ Feature: Relation Inference Resolution
       (baseRole: $z) isa subSubRelation;
       """
     Given for each session, transaction commits
-    Given sessions open transactions of type: write
+    Given for each session, open transactions of type: write
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa derivedRelation;
@@ -1192,7 +1184,7 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa! derivedRelation;
@@ -1200,7 +1192,7 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa directDerivedRelation;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -83,7 +83,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -120,7 +120,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -161,7 +161,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -199,7 +199,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -238,7 +238,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $r isa friendship;
@@ -274,7 +274,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match ($x, $y) isa friendship;
@@ -305,7 +305,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -333,7 +333,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -363,7 +363,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -424,7 +424,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $x) isa coworkers;
@@ -481,7 +481,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa location-hierarchy;
@@ -517,7 +517,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
@@ -580,7 +580,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
@@ -613,7 +613,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment;
@@ -641,7 +641,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x) isa employment;
@@ -672,7 +672,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
@@ -680,7 +680,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -721,7 +721,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -744,7 +744,7 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -783,7 +783,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -822,7 +822,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -881,7 +881,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match ($a, $b) isa relation;
@@ -891,7 +891,7 @@ Feature: Relation Inference Resolution
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match ($a, $b);
@@ -923,7 +923,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -995,7 +995,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa derivedRelation;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -82,6 +82,9 @@ Feature: Relation Inference Resolution
       $z isa person;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -117,6 +120,9 @@ Feature: Relation Inference Resolution
       $y isa person, has name "Michael";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -156,6 +162,9 @@ Feature: Relation Inference Resolution
       $y 14.99 isa price;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -192,6 +201,9 @@ Feature: Relation Inference Resolution
       $y 1664 isa year;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -229,6 +241,9 @@ Feature: Relation Inference Resolution
       $e isa person, has name "Eustace";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $r isa friendship;
@@ -263,6 +278,9 @@ Feature: Relation Inference Resolution
       $e isa person, has name "Eustace";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match ($x, $y) isa friendship;
@@ -292,6 +310,9 @@ Feature: Relation Inference Resolution
       $h isa person, has name "Hattie";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -318,6 +339,9 @@ Feature: Relation Inference Resolution
       $i isa person, has name "Irma";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -346,6 +370,9 @@ Feature: Relation Inference Resolution
       $j isa person, has name "Jane";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -405,6 +432,9 @@ Feature: Relation Inference Resolution
       (coworker: $b, coworker: $c) isa coworkers;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $x) isa coworkers;
@@ -460,6 +490,9 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $y) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa location-hierarchy;
@@ -494,6 +527,9 @@ Feature: Relation Inference Resolution
       (subordinate: $c, superior: $d) isa location-hierarchy;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
@@ -555,6 +591,9 @@ Feature: Relation Inference Resolution
       (subordinate: $x3, superior: $x4) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
@@ -586,6 +625,9 @@ Feature: Relation Inference Resolution
       $c isa company;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment;
@@ -612,6 +654,9 @@ Feature: Relation Inference Resolution
       $c isa company;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (employee: $x) isa employment;
@@ -641,12 +686,18 @@ Feature: Relation Inference Resolution
       $z isa person, has name "Charlie";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -686,6 +737,9 @@ Feature: Relation Inference Resolution
       (choice1: $y, choice2: $z) isa selection;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -707,6 +761,9 @@ Feature: Relation Inference Resolution
       """
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -744,6 +801,9 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -781,6 +841,9 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -838,6 +901,9 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match ($a, $b) isa relation;
@@ -846,6 +912,9 @@ Feature: Relation Inference Resolution
     # Despite there being more inferred relations, the answer size is still 6 (as in the previous scenario)
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then answer set is equivalent for graql query
       """
       match ($a, $b);
@@ -876,6 +945,9 @@ Feature: Relation Inference Resolution
       (subordinate: $y, superior: $z) isa location-hierarchy;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -946,6 +1018,9 @@ Feature: Relation Inference Resolution
       (baseRole: $z) isa subSubRelation;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match ($x) isa derivedRelation;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -83,7 +83,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -120,7 +120,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -161,7 +161,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -199,7 +199,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -238,7 +238,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $r isa friendship;
@@ -274,7 +274,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x, $y) isa friendship;
@@ -305,7 +305,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -333,7 +333,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -363,7 +363,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -424,7 +424,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $x) isa coworkers;
@@ -481,7 +481,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa location-hierarchy;
@@ -517,7 +517,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
@@ -580,7 +580,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
@@ -613,7 +613,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment;
@@ -641,7 +641,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (employee: $x) isa employment;
@@ -672,7 +672,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
@@ -680,7 +680,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -721,7 +721,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -744,7 +744,7 @@ Feature: Relation Inference Resolution
 #    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -783,7 +783,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -822,7 +822,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -881,7 +881,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match ($a, $b) isa relation;
@@ -891,7 +891,7 @@ Feature: Relation Inference Resolution
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then answer set is equivalent for graql query
       """
       match ($a, $b);
@@ -923,7 +923,7 @@ Feature: Relation Inference Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -995,7 +995,7 @@ Feature: Relation Inference Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match ($x) isa derivedRelation;

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -24,8 +24,8 @@ Feature: Resolution Test Framework
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
 
 
   Scenario: basic rule
@@ -49,7 +49,7 @@ Feature: Resolution Test Framework
       insert
       $x isa company;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -93,7 +93,7 @@ Feature: Resolution Test Framework
       $co isa company;
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -143,7 +143,7 @@ Feature: Resolution Test Framework
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -202,7 +202,7 @@ Feature: Resolution Test Framework
       (location-hierarchy_superior: $cit, location-hierarchy_subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -254,7 +254,7 @@ Feature: Resolution Test Framework
       $b isa man;
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -296,7 +296,7 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -342,7 +342,7 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -384,7 +384,7 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -50,8 +50,8 @@ Feature: Resolution Test Framework
       $x isa company;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $co has name $n;
@@ -94,8 +94,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $co has is-liable $l;
@@ -144,8 +144,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -203,8 +203,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
@@ -255,8 +255,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman;
@@ -297,8 +297,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company;
@@ -343,8 +343,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true;
@@ -385,8 +385,8 @@ Feature: Resolution Test Framework
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -51,7 +51,7 @@ Feature: Resolution Test Framework
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $co has name $n;
@@ -95,7 +95,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $co has is-liable $l;
@@ -145,7 +145,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -204,7 +204,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
@@ -256,7 +256,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman;
@@ -298,7 +298,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company;
@@ -344,7 +344,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true;
@@ -386,7 +386,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -24,8 +24,8 @@ Feature: Resolution Test Framework
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
 
 
   Scenario: basic rule
@@ -51,7 +51,6 @@ Feature: Resolution Test Framework
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -96,7 +95,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -147,7 +145,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -207,7 +204,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -260,7 +256,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -303,7 +298,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -350,7 +344,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -393,7 +386,6 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -50,6 +50,9 @@ Feature: Resolution Test Framework
       $x isa company;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $co has name $n;
@@ -92,6 +95,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $co has is-liable $l;
@@ -140,6 +146,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -197,6 +206,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
@@ -247,6 +259,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman;
@@ -287,6 +302,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $com isa company;
@@ -331,6 +349,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true;
@@ -371,6 +392,9 @@ Feature: Resolution Test Framework
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -51,7 +51,7 @@ Feature: Resolution Test Framework
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $co has name $n;
@@ -95,7 +95,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $co has is-liable $l;
@@ -145,7 +145,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -204,7 +204,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
@@ -256,7 +256,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman;
@@ -298,7 +298,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company;
@@ -344,7 +344,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true;
@@ -386,7 +386,7 @@ Feature: Resolution Test Framework
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -24,8 +24,8 @@ Feature: Rule Interaction Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -107,7 +107,6 @@ Feature: Rule Interaction Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -163,7 +162,6 @@ Feature: Rule Interaction Resolution
 
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -24,8 +24,8 @@ Feature: Rule Interaction Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -105,7 +105,7 @@ Feature: Rule Interaction Resolution
       (attendee: $charlie, speaker: $dennis) isa conference;
       (member: $charlie, member: $dennis, host: $charlie) isa party;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -160,7 +160,7 @@ Feature: Rule Interaction Resolution
       (husband: $a, wife: $b) isa marriage;
       """
 
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -107,7 +107,7 @@ Feature: Rule Interaction Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name $n, has tag "P";
@@ -162,7 +162,7 @@ Feature: Rule Interaction Resolution
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name 'tracey';

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -106,8 +106,8 @@ Feature: Rule Interaction Resolution
       (member: $charlie, member: $dennis, host: $charlie) isa party;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name $n, has tag "P";
@@ -161,8 +161,8 @@ Feature: Rule Interaction Resolution
       """
 
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name 'tracey';

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -107,7 +107,7 @@ Feature: Rule Interaction Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name $n, has tag "P";
@@ -162,7 +162,7 @@ Feature: Rule Interaction Resolution
 
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x isa person, has name 'tracey';

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -106,6 +106,9 @@ Feature: Rule Interaction Resolution
       (member: $charlie, member: $dennis, host: $charlie) isa party;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa person, has name $n, has tag "P";
@@ -159,6 +162,9 @@ Feature: Rule Interaction Resolution
       """
 
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x isa person, has name 'tracey';

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -87,7 +87,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa entity;
@@ -141,7 +141,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match ($u, $v) isa relation;
@@ -202,7 +202,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -249,7 +249,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -312,7 +312,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -363,7 +363,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -422,7 +422,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -86,8 +86,8 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa entity;
@@ -140,8 +140,8 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person, has name "Rupert";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match ($u, $v) isa relation;
@@ -201,8 +201,8 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Tobias";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -248,8 +248,8 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person, has name "Rupert";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -311,8 +311,8 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Tobias";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -362,8 +362,8 @@ Feature: Schema Query Resolution (Variable Types)
       $w isa colonel;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -421,8 +421,8 @@ Feature: Schema Query Resolution (Variable Types)
       (employee: $s4, employer: $c2prime) isa employment;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -24,8 +24,8 @@ Feature: Schema Query Resolution (Variable Types)
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -85,7 +85,7 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person;
       $z isa person;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -139,7 +139,7 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Richard";
       $z isa person, has name "Rupert";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -200,7 +200,7 @@ Feature: Schema Query Resolution (Variable Types)
       $x isa person, has name "Sharon";
       $y isa person, has name "Tobias";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -247,7 +247,7 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Richard";
       $z isa person, has name "Rupert";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -310,7 +310,7 @@ Feature: Schema Query Resolution (Variable Types)
       $x isa person, has name "Sharon";
       $y isa person, has name "Tobias";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -361,7 +361,7 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa colonel;
       $w isa colonel;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -420,7 +420,7 @@ Feature: Schema Query Resolution (Variable Types)
       (employee: $s3, employer: $c2) isa employment;
       (employee: $s4, employer: $c2prime) isa employment;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -87,7 +87,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa entity;
@@ -141,7 +141,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match ($u, $v) isa relation;
@@ -202,7 +202,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -249,7 +249,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -312,7 +312,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -363,7 +363,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -422,7 +422,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -24,8 +24,8 @@ Feature: Schema Query Resolution (Variable Types)
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -87,7 +87,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -142,7 +141,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -204,7 +202,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -252,7 +249,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -316,7 +312,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -368,7 +363,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -428,7 +422,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -86,6 +86,9 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa entity;
@@ -138,6 +141,9 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person, has name "Rupert";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match ($u, $v) isa relation;
@@ -197,6 +203,9 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Tobias";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -242,6 +251,9 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa person, has name "Rupert";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -303,6 +315,9 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Tobias";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -352,6 +367,9 @@ Feature: Schema Query Resolution (Variable Types)
       $w isa colonel;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -409,6 +427,9 @@ Feature: Schema Query Resolution (Variable Types)
       (employee: $s4, employer: $c2prime) isa employment;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -108,7 +108,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match $x isa $type;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # 3 people x 3 types of person {person,entity,thing}
     # 6 friendships x 3 types of friendship {friendship, relation, thing}
     # 1 name x 3 types of name {name,attribute,thing}
@@ -152,7 +152,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match ($u, $v) isa $type;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # 3 possible $u x 3 possible $v x 3 possible $type {friendship,relation,thing}
     Then answer size in reasoned database is: 27
     Then materialised and reasoned databases are the same size
@@ -215,7 +215,7 @@ Feature: Schema Query Resolution (Variable Types)
         $x isa $type;
         $type owns contract;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # friendship can't have a contract... at least, not in this pristine test world
     # note: enforcing 'has contract' also eliminates 'relation' and 'thing' as possible types
     Then answer size in reasoned database is: 4
@@ -262,7 +262,7 @@ Feature: Schema Query Resolution (Variable Types)
         $x isa $type;
         $type sub relation;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # 3 friendships, 3 employments, 6 relations
     Then answer size in reasoned database is: 12
     Then materialised and reasoned databases are the same size
@@ -325,7 +325,7 @@ Feature: Schema Query Resolution (Variable Types)
         $x isa $type;
         $type plays legal-documentation:subject;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # friendship can't be a documented-thing
     # note: enforcing 'plays legal-documentation:subject' also eliminates 'relation' and 'thing' as possible types
     Then answer size in reasoned database is: 4
@@ -376,7 +376,7 @@ Feature: Schema Query Resolution (Variable Types)
         (employee: $x, employer: $y) isa employment;
         $x isa $type;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # 3 colonels * 5 supertypes of colonel (colonel, military-person, person, entity, thing)
     Then answer size in reasoned database is: 15
     Then for graql query
@@ -385,7 +385,7 @@ Feature: Schema Query Resolution (Variable Types)
         ($x, $y) isa employment;
         $x isa $type;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # (3 colonels * 5 supertypes of colonel * 1 company)
     # + (1 company * 3 supertypes of company * 3 colonels)
     Then answer size in reasoned database is: 24
@@ -435,7 +435,7 @@ Feature: Schema Query Resolution (Variable Types)
         not { $y is $x; };
       get $x, $y;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # All companies match when $type is company (or entity)
     # Query returns {ab,ac,ad,bc,bd,cd} and each of them with the variables flipped
     Then answer size in reasoned database is: 12

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -75,7 +75,7 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
         Given transaction commits
-    Given sessions open transactions with reasoning of type:read
+    Given for each session, open transactions with reasoning of type:read
 
     Then for graql query
       """
@@ -174,8 +174,8 @@ Feature: Type Hierarchy Resolution
       (child: $x, parent: $y) isa family;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     # Matching a sibling of the actual role
     Then for graql query
       """
@@ -230,8 +230,8 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     # sub-roles, super-relation
     Then for graql query
       """
@@ -281,8 +281,8 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     # super-roles, sub-relation
     Then for graql query
       """
@@ -332,8 +332,8 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     # super-roles, super-relation
     Then for graql query
       """
@@ -399,8 +399,8 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -503,8 +503,8 @@ Feature: Type Hierarchy Resolution
       (parent:$x, child:$y) isa family;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (home-owner: $x, resident: $y) isa residence;

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -74,7 +74,10 @@ Feature: Type Hierarchy Resolution
       (performer:$x, writer:$v) isa performance;  # child - child    -> satisfies rule
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
-    When materialised database is completed
+        Given transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type:read
+
     Then for graql query
       """
       match
@@ -172,6 +175,9 @@ Feature: Type Hierarchy Resolution
       (child: $x, parent: $y) isa family;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     # Matching a sibling of the actual role
     Then for graql query
       """
@@ -226,6 +232,9 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     # sub-roles, super-relation
     Then for graql query
       """
@@ -275,6 +284,9 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     # super-roles, sub-relation
     Then for graql query
       """
@@ -324,6 +336,9 @@ Feature: Type Hierarchy Resolution
       (writer:$x, performer:$y) isa performance;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     # super-roles, super-relation
     Then for graql query
       """
@@ -389,6 +404,9 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -491,6 +509,9 @@ Feature: Type Hierarchy Resolution
       (parent:$x, child:$y) isa family;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (home-owner: $x, resident: $y) isa residence;

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -24,8 +24,8 @@ Feature: Type Hierarchy Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
 
 
   Scenario: subtypes trigger rules based on their parents; parent types don't trigger rules based on their children
@@ -75,7 +75,6 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
         Given transaction commits
-    Given the integrity is validated
     Given session opens transaction of type:read
 
     Then for graql query
@@ -176,7 +175,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     # Matching a sibling of the actual role
     Then for graql query
@@ -233,7 +231,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     # sub-roles, super-relation
     Then for graql query
@@ -285,7 +282,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     # super-roles, sub-relation
     Then for graql query
@@ -337,7 +333,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     # super-roles, super-relation
     Then for graql query
@@ -405,7 +400,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -510,7 +504,6 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -75,7 +75,7 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
         Given transaction commits
-    Given session opens transaction of type:read
+    Given session opens transactions with reasoning of type:read
 
     Then for graql query
       """
@@ -175,7 +175,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     # Matching a sibling of the actual role
     Then for graql query
       """
@@ -231,7 +231,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     # sub-roles, super-relation
     Then for graql query
       """
@@ -282,7 +282,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     # super-roles, sub-relation
     Then for graql query
       """
@@ -333,7 +333,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     # super-roles, super-relation
     Then for graql query
       """
@@ -400,7 +400,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -504,7 +504,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (home-owner: $x, resident: $y) isa residence;

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -24,8 +24,8 @@ Feature: Type Hierarchy Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
 
 
   Scenario: subtypes trigger rules based on their parents; parent types don't trigger rules based on their children
@@ -173,7 +173,7 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (child: $x, parent: $y) isa family;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     # Matching a sibling of the actual role
@@ -229,7 +229,7 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     # sub-roles, super-relation
@@ -280,7 +280,7 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     # super-roles, sub-relation
@@ -331,7 +331,7 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     # super-roles, super-relation
@@ -398,7 +398,7 @@ Feature: Type Hierarchy Resolution
       (performer:$x, writer:$v) isa performance;  # child - child    -> satisfies rule
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -502,7 +502,7 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (parent:$x, child:$y) isa family;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -75,7 +75,7 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
         Given transaction commits
-    Given session opens transactions with reasoning of type:read
+    Given sessions open transactions with reasoning of type:read
 
     Then for graql query
       """
@@ -175,7 +175,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     # Matching a sibling of the actual role
     Then for graql query
       """
@@ -231,7 +231,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     # sub-roles, super-relation
     Then for graql query
       """
@@ -282,7 +282,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     # super-roles, sub-relation
     Then for graql query
       """
@@ -333,7 +333,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     # super-roles, super-relation
     Then for graql query
       """
@@ -400,7 +400,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -504,7 +504,7 @@ Feature: Type Hierarchy Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (home-owner: $x, resident: $y) isa residence;

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -82,8 +82,8 @@ Feature: Value Predicate Resolution
       $se isa tortoise, has age 1;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has is-old $r;
@@ -111,8 +111,8 @@ Feature: Value Predicate Resolution
       $y isa person;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -150,8 +150,8 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -191,8 +191,8 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -241,8 +241,8 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -284,8 +284,8 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -330,8 +330,8 @@ Feature: Value Predicate Resolution
       insert $x isa soft-drink, has name "Fanta";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -374,8 +374,8 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -429,8 +429,8 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -487,8 +487,8 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -537,8 +537,8 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -588,8 +588,8 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -633,8 +633,8 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tesco";
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -714,8 +714,8 @@ Feature: Value Predicate Resolution
       $p4 "cheap" isa price-range;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -811,8 +811,8 @@ Feature: Value Predicate Resolution
       (original:$x, reply:$x5) isa reply-of;
       """
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -83,7 +83,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match $x has is-old $r;
@@ -112,7 +112,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -151,7 +151,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -192,7 +192,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -242,7 +242,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -285,7 +285,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -331,7 +331,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -375,7 +375,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -430,7 +430,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -488,7 +488,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -538,7 +538,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -589,7 +589,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -634,7 +634,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -715,7 +715,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -812,7 +812,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -83,7 +83,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match $x has is-old $r;
@@ -112,7 +112,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -151,7 +151,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -192,7 +192,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -242,7 +242,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -285,7 +285,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -331,7 +331,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -375,7 +375,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -430,7 +430,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -488,7 +488,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -538,7 +538,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match
@@ -589,7 +589,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -634,7 +634,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -715,7 +715,7 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -812,7 +812,7 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -24,8 +24,8 @@ Feature: Value Predicate Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -81,7 +81,7 @@ Feature: Value Predicate Resolution
       insert
       $se isa tortoise, has age 1;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -110,7 +110,7 @@ Feature: Value Predicate Resolution
       $x isa person;
       $y isa person;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -149,7 +149,7 @@ Feature: Value Predicate Resolution
       $x isa person, has name "Alice";
       $y isa person, has name "Bob";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -190,7 +190,7 @@ Feature: Value Predicate Resolution
       $x isa person, has name "Alice";
       $y isa person, has name "Bob";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -240,7 +240,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -283,7 +283,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -329,7 +329,7 @@ Feature: Value Predicate Resolution
       """
       insert $x isa soft-drink, has name "Fanta";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -373,7 +373,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -428,7 +428,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -486,7 +486,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -536,7 +536,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -587,7 +587,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -632,7 +632,7 @@ Feature: Value Predicate Resolution
       $x isa person, has string-attribute "Tesco";
       $y isa soft-drink, has name "Tesco";
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -713,7 +713,7 @@ Feature: Value Predicate Resolution
       $p3 "low price" isa price-range;
       $p4 "cheap" isa price-range;
       """
-    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -810,7 +810,7 @@ Feature: Value Predicate Resolution
       (original:$x, reply:$x4) isa reply-of;
       (original:$x, reply:$x5) isa reply-of;
       """
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -121,7 +121,7 @@ Feature: Value Predicate Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: <answer-size>
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -159,9 +159,9 @@ Feature: Value Predicate Resolution
         $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: <answer-size>
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -201,9 +201,9 @@ Feature: Value Predicate Resolution
         $m <op> $n;
         $n <op> 1667;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: <answer-size>
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -340,7 +340,7 @@ Feature: Value Predicate Resolution
       """
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -384,7 +384,7 @@ Feature: Value Predicate Resolution
         $rx = $ry;
         $ry contains 'land';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Iceland   |
     # Tango | Iceland   | Fanta | Iceland   |
@@ -395,7 +395,7 @@ Feature: Value Predicate Resolution
     # Tango | Iceland   | Tango | Iceland   |
     # Tango | Poundland | Tango | Poundland |
     Then answer size in reasoned database is: 8
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -439,7 +439,7 @@ Feature: Value Predicate Resolution
         $rx != $ry;
         $ry contains 'land';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Poundland |
     # Tango | Iceland   | Fanta | Poundland |
@@ -458,7 +458,7 @@ Feature: Value Predicate Resolution
     # Fanta | Londis    | Fanta | Iceland   |
     # Tango | Londis    | Tango | Iceland   |
     Then answer size in reasoned database is: 16
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: in a rule, 'not { $x = $y; }' is the same as saying '$x != $y'
@@ -738,7 +738,7 @@ Feature: Value Predicate Resolution
         $x "cheap" isa price-range;
         ($x, priced-item: $y) isa price-classification;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for graql query
       """
@@ -754,7 +754,7 @@ Feature: Value Predicate Resolution
         $x isa price-range;
         ($x, priced-item: $y) isa price-classification;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # sum of all previous answers
     Then answer size in reasoned database is: 5
     Then materialised and reasoned databases are the same size
@@ -817,7 +817,7 @@ Feature: Value Predicate Resolution
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then answer size in reasoned database is: 10
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -24,8 +24,8 @@ Feature: Value Predicate Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -83,7 +83,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -113,7 +112,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -153,7 +151,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -195,7 +192,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -246,7 +242,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -290,7 +285,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -337,7 +331,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -382,7 +375,6 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -438,7 +430,6 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -497,7 +488,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -548,7 +538,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -600,7 +589,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -646,7 +634,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -728,7 +715,6 @@ Feature: Value Predicate Resolution
       """
     When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -826,7 +812,6 @@ Feature: Value Predicate Resolution
       """
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -82,6 +82,9 @@ Feature: Value Predicate Resolution
       $se isa tortoise, has age 1;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match $x has is-old $r;
@@ -109,6 +112,9 @@ Feature: Value Predicate Resolution
       $y isa person;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -146,6 +152,9 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -185,6 +194,9 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -233,6 +245,9 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -274,6 +289,9 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -318,6 +336,9 @@ Feature: Value Predicate Resolution
       insert $x isa soft-drink, has name "Fanta";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -360,6 +381,9 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -413,6 +437,9 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -469,6 +496,9 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -517,6 +547,9 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match
@@ -566,6 +599,9 @@ Feature: Value Predicate Resolution
       $r "Ocado" isa retailer;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -609,6 +645,9 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tesco";
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -688,6 +727,9 @@ Feature: Value Predicate Resolution
       $p4 "cheap" isa price-range;
       """
     When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -783,6 +825,9 @@ Feature: Value Predicate Resolution
       (original:$x, reply:$x5) isa reply-of;
       """
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -152,7 +152,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -172,7 +172,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -195,7 +195,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -217,7 +217,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -242,7 +242,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -267,7 +267,7 @@ Feature: Variable Role Resolution
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -293,7 +293,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -366,7 +366,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -409,7 +409,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -451,7 +451,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transactions with reasoning of type: read
+    Given sessions open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -25,8 +25,8 @@ Feature: Variable Role Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised session has database name: materialised
-    Given reasoned session has database name: reasoned
+
+
     Given for each session, graql define
       """
       define
@@ -150,7 +150,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -170,7 +170,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -193,7 +193,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -215,7 +215,7 @@ Feature: Variable Role Resolution
   @ignore
   # TODO: need to determine what this should do; currently it returns 12 answers (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -240,7 +240,7 @@ Feature: Variable Role Resolution
   @ignore
   # TODO: need to determine what this should do; currently it errors (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -265,7 +265,7 @@ Feature: Variable Role Resolution
   @ignore
   # TODO: re-enable when converting a fixed role to a variable bound with meta 'role' does not modify the answer
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -291,7 +291,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Given for graql query
@@ -364,7 +364,7 @@ Feature: Variable Role Resolution
   #  }
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -407,7 +407,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query
@@ -449,7 +449,7 @@ Feature: Variable Role Resolution
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
-#    When materialised database is completed
+    Then materialised database is completed
     Given the transaction commits
     Given sessions open transactions with reasoning of type: read
     Then for graql query

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -151,8 +151,8 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -171,8 +171,8 @@ Feature: Variable Role Resolution
 
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -194,8 +194,8 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -216,8 +216,8 @@ Feature: Variable Role Resolution
   # TODO: need to determine what this should do; currently it returns 12 answers (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -241,8 +241,8 @@ Feature: Variable Role Resolution
   # TODO: need to determine what this should do; currently it errors (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -266,8 +266,8 @@ Feature: Variable Role Resolution
   # TODO: re-enable when converting a fixed role to a variable bound with meta 'role' does not modify the answer
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -292,8 +292,8 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -365,8 +365,8 @@ Feature: Variable Role Resolution
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -408,8 +408,8 @@ Feature: Variable Role Resolution
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -450,8 +450,8 @@ Feature: Variable Role Resolution
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
     Then materialised database is completed
-    Given the transaction commits
-    Given sessions open transactions with reasoning of type: read
+    Given for each session, transaction commits
+    Given for each session, open transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -152,7 +152,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -172,7 +172,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -195,7 +195,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -217,7 +217,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -242,7 +242,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -267,7 +267,7 @@ Feature: Variable Role Resolution
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -293,7 +293,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -366,7 +366,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -409,7 +409,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match
@@ -451,7 +451,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given session opens transaction of type: read
+    Given session opens transactions with reasoning of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -151,6 +151,9 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -169,6 +172,9 @@ Feature: Variable Role Resolution
 
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -190,6 +196,9 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -210,6 +219,9 @@ Feature: Variable Role Resolution
   # TODO: need to determine what this should do; currently it returns 12 answers (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -233,6 +245,9 @@ Feature: Variable Role Resolution
   # TODO: need to determine what this should do; currently it errors (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -256,6 +271,9 @@ Feature: Variable Role Resolution
   # TODO: re-enable when converting a fixed role to a variable bound with meta 'role' does not modify the answer
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -280,6 +298,9 @@ Feature: Variable Role Resolution
 
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -351,6 +372,9 @@ Feature: Variable Role Resolution
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -392,6 +416,9 @@ Feature: Variable Role Resolution
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match
@@ -432,6 +459,9 @@ Feature: Variable Role Resolution
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
 #    When materialised database is completed
+    Given the transaction commits
+    Given the integrity is validated
+    Given session opens transaction of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -157,16 +157,16 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
       """
     # $r1 in {role, role2} (2 options => double answer size)
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 18
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
@@ -177,7 +177,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, $r1: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 18
     # This query should be equivalent to the one above
     Then for graql query
@@ -187,9 +187,9 @@ Feature: Variable Role Resolution
         $r1 type role1;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 18
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
@@ -200,16 +200,16 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
       """
     # $r1 in {role, role1, role2} (3 options => triple answer size)
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -222,7 +222,7 @@ Feature: Variable Role Resolution
       """
       match (role: $a, $r1: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
     # This query should be equivalent to the one above
     Then for graql query
@@ -232,9 +232,9 @@ Feature: Variable Role Resolution
         $r1 type role;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -247,7 +247,7 @@ Feature: Variable Role Resolution
       """
       match (role: $a, $r1: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
     # This query should be equivalent to the one above
     Then for graql query
@@ -257,9 +257,9 @@ Feature: Variable Role Resolution
         $r1 sub role;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -276,7 +276,7 @@ Feature: Variable Role Resolution
         $r2 type role2;
       """
     # $r1 must be 'role' and $r2 must be 'role2'
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 9
     # This query is equivalent to the one above
     Then for graql query
@@ -285,9 +285,9 @@ Feature: Variable Role Resolution
         (role: $a, $r2: $b) isa binary-base;
         $r2 type role2;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 9
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
@@ -298,7 +298,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-#    Given all answers are correct in reasoned database
+    Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for graql query
       """
@@ -312,9 +312,9 @@ Feature: Variable Role Resolution
     # role1 | role2 |
     # role2 | role  |
     # role2 | role1 |
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 63
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # General formula for the answer size with K degrees of freedom [*] on an N-ary relation
@@ -373,21 +373,21 @@ Feature: Variable Role Resolution
         (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
         $a1 has name 'a';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
     Then answer size in reasoned database is: 63
     Then for graql query
       """
       match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then answer size in reasoned database is: 189
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # r1    | r2    | r3    |
     # role  | role  | role  | 1 pattern
     # roleX | role  | role  | 3 patterns: X in {1,2,3}
@@ -403,7 +403,7 @@ Feature: Variable Role Resolution
     # and there are 27 ternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 34 * 27 = 918
     Then answer size in reasoned database is: 918
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
@@ -416,21 +416,21 @@ Feature: Variable Role Resolution
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
         $a1 has name 'a';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
     Then answer size in reasoned database is: 918
     Then for graql query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then answer size in reasoned database is: 2754
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # {r1,r2,r3,r4}
     # 4 occurrences of 'role' | 1 pattern
     # 3 occurrences of 'role' | 16 patterns (4 combinations of 1 role var x (4) distinct roles)
@@ -443,7 +443,7 @@ Feature: Variable Role Resolution
     # and there are 81 quaternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 81 = 16929
     Then answer size in reasoned database is: 16929
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
@@ -458,24 +458,24 @@ Feature: Variable Role Resolution
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
         $a1 has name 'a';
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
     Then answer size in reasoned database is: 272
     Then for graql query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
     Then answer size in reasoned database is: 544
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       """
-#    Then all answers are correct in reasoned database
+    Then all answers are correct in reasoned database
     # {r1,r2,r3,r4} | 209 patterns (see 'quaternary-base' scenario for details)
     # For each pattern, we have one possible match per quaternary relation
     # and there are 16 quaternary relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 16 = 3344
     Then answer size in reasoned database is: 3344
-#    Then materialised and reasoned databases are the same size
+    Then materialised and reasoned databases are the same size

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -25,8 +25,8 @@ Feature: Variable Role Resolution
     Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised database is named: materialised
-    Given reasoned database is named: reasoned
+    Given materialised session has database name: materialised
+    Given reasoned session has database name: reasoned
     Given for each session, graql define
       """
       define
@@ -152,7 +152,6 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -173,7 +172,6 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -197,7 +195,6 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -220,7 +217,6 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -246,7 +242,6 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -272,7 +267,6 @@ Feature: Variable Role Resolution
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -299,7 +293,6 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Given for graql query
       """
@@ -373,7 +366,6 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -417,7 +409,6 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """
@@ -460,7 +451,6 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
 #    When materialised database is completed
     Given the transaction commits
-    Given the integrity is validated
     Given session opens transaction of type: read
     Then for graql query
       """


### PR DESCRIPTION
## What is the goal of this PR?

We update reasoning BDD to be compatible with grakn 2.0 BDD steps, including opening and closing transactions explicitly, and handling data/schema session split. This PR only completely updates 3 files, and partially updates the remainder:
* `arithmetic-equality.feature`
* `attribute-attachment.feature`
* `relation-inference.feature`

## What are the changes implemented in this PR?
* explicitly open and commit and close transactions
* manage schema and data sessions correctly
* remove overly verbose steps `reasoned keyspace is named: reasoned` and `materialised keyspace is named: materialised`

## Work recap, required for part 2

* update any schemas and unsatisfiable rules/queries to allow tests to run
* open data or schema sessions for two hardcoded names, reasoned and materialised
* close data/schema sessions when switching from define, to insert or matching data
* explicitly commit/close, and re-open transactions
  * if opening a read transaction, open it with reasoning: `Given for each session, open transactions with reasoning of type: read` [this will go away when reasoning on by default in the future]
* always open write transaction and commit, and reopen transaction around a `Then materialised database is completed`
* always re-open a new transaction before doing a `Given for graql query`, because we want to always execute reasoning queries on a clean database without materialised answers
* uncomment all commented steps to do with materialised database operations, which are just no-ops in the implementation steps for now



Example of switching from schema to data session and reopening transactions:
```
    Given for each session, transaction commits
    Given connection close all sessions
    Given connection open data sessions for databases:
      | reasoned     |
      | materialised |
    Given for each session, open transactions of type: write
    ```
