### PR TITLE
Deleted vertex modification tests

### DIFF
--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -215,7 +215,7 @@ Feature: Concept Entity
     Then entity $a get attributes(email) as(string) do not contain: $email
     Then attribute $email get owners do not contain: $a
 
-
+  @ignore
   Scenario: Entity cannot be given an attribute after deletion
     When $a = entity(person) create new instance with key(username): alice
     When $email = attribute(email) as(string) put: alice@email.com

--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -215,6 +215,14 @@ Feature: Concept Entity
     Then entity $a get attributes(email) as(string) do not contain: $email
     Then attribute $email get owners do not contain: $a
 
+
+  Scenario: Entity cannot be given an attribute after deletion
+    When $a = entity(person) create new instance with key(username): alice
+    When $email = attribute(email) as(string) put: alice@email.com
+    When delete entity: $a
+    Then entity $a is deleted: true
+    When entity $a set has: $email; throws exception
+
   Scenario: Entity can play a role in a relation
 
   Scenario: Entity can retrieve relations where it plays a role in

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -212,6 +212,8 @@ Feature: Concept Relation
     Then relation $m is null: true
     Then relation(marriage) get instances is empty
 
+#Both of the below presently fail with an NPE possibly unrelated to interaction with deleted vertex- investigation required
+  @ignore
   Scenario: Relation cannot have roleplayers inserted after deletion
     When $m = relation(marriage) create new instance with key(license): m
     When $a = entity(person) create new instance with key(username): alice
@@ -220,6 +222,7 @@ Feature: Concept Relation
     Then relation $r is deleted: true
     When relation $m add player for role(wife): $a; throws exception
 
+  @ignore
   Scenario: Relation cannot have roleplayers inserted after indirect deletion
     When $m = relation(marriage) create new instance with key(license): m
     When $a = entity(person) create new instance with key(username): alice

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -211,3 +211,19 @@ Feature: Concept Relation
     When $m = relation(marriage) get instance with key(license): m
     Then relation $m is null: true
     Then relation(marriage) get instances is empty
+
+  Scenario: Relation cannot have roleplayers inserted after deletion
+    When $m = relation(marriage) create new instance with key(license): m
+    When $a = entity(person) create new instance with key(username): alice
+    When relation $m add player for role(wife): $a
+    When delete relation: $r
+    Then relation $r is deleted: true
+    When relation $m add player for role(wife): $a; throws exception
+
+  Scenario: Relation cannot have roleplayers inserted after indirect deletion
+    When $m = relation(marriage) create new instance with key(license): m
+    When $a = entity(person) create new instance with key(username): alice
+    When relation $m add player for role(wife): $a
+    When delete entity: $a
+    Then relation $r is deleted: true
+    When relation $m add player for role(wife): $a; throws exception


### PR DESCRIPTION
## What is the goal of this PR?

We added a number of tests (and immediately ignored all of them) to test the cases where we delete a thing, then try to write to it. The actual behaviour modification follows.

## What are the changes implemented in this PR?

Added the test scenarios:
- entity.feature: Entity cannot be given an attribute after deletion
- relation.feature: Relation cannot have roleplayers inserted after deletion
- relation.feature: Relation cannot have roleplayers inserted after indirect deletion