### PR TITLE
Reopen transaction to identify concepts

### DIFF
--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -1293,6 +1293,7 @@ Feature: Graql Insert Query
       $x 10;
       """
     Then transaction commits
+    Given session opens transaction of type: read
     Then uniquely identify answer concepts
       | x            |
       | value:age:10 |


### PR DESCRIPTION
## What is the goal of this PR?

Tests were erroneously failing in clients due to not having an open transaction to check identifiers against.

## What are the changes implemented in this PR?

Made new transaction for uniquely identifying concepts in `Scenario: when inserting an attribute, the type and value can be specified in two individual statements`- when identifying concepts, we need a querymanager to check their values against, but the commit now closes the existing transaction