### PR TITLE
Fix "Last Roleplayer" Scenario

### DIFF
--- a/graql/language/update.feature
+++ b/graql/language/update.feature
@@ -87,7 +87,7 @@ Feature: Graql Update Query
       insert
       $x isa person, has name "Alex", has ref 0;
       $y isa person, has name "Bob", has ref 1;
-      $r (friend: $x, friend:$y) isa friendship, has ref 0;
+      $r (friend: $x) isa friendship, has ref 0;
       """
     Given transaction commits
     Given session opens transaction of type: write


### PR DESCRIPTION
## What is the goal of this PR?

The last roleplayer scenario erroneously had two last roleplayers instead of one. We removed one of them.

## What are the changes implemented in this PR?

Fixed `Scenario: Deleting the last roleplayer of a relation means it cannot be updated`
