### PR TITLE
Fix label of key attribute in delete scenario

### DIFF
--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -177,7 +177,7 @@ Feature: Graql Delete Query
       """
     Then uniquely identify answer concepts
       | x             | y            | r         | n               |
-      | key:name:Alex | key:name:Bob | ket:ref:0 | value:name:John |
+      | key:name:Alex | key:name:Bob | key:ref:0 | value:name:John |
     Given transaction commits
     Given session opens transaction of type: write
     When graql delete


### PR DESCRIPTION
## What is the goal of this PR?

A scenario said ket. It meant key. We made it say key.

## What are the changes implemented in this PR?

As above
