### PR TITLE
Add variable roles match query

### DIFF
--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -939,6 +939,29 @@ Feature: Graql Match Query
       | key:ref:0 | key:ref:1 |
 
 
+  Scenario: a mixture of variable and explicit roles can retrieve relations
+    Given connection close all sessions
+    Given connection open data session for database: grakn
+    Given session opens transaction of type: write
+    Given graql insert
+      """
+      insert
+      $x isa company, has ref 0;
+      $y isa person, has ref 1;
+      (employer: $x, employee: $y) isa employment, has ref 2;
+      """
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of graql match
+      """
+      match (employer: $e, $role: $x) isa employment;
+      """
+    Then uniquely identify answer concepts
+      | e         | x         | role                      |
+      | key:ref:0 | key:ref:1 | label:employment:employee |
+      | key:ref:0 | key:ref:1 | label:relation:role       |
+
+
   Scenario: relations between distinct concepts are not retrieved when matching concepts that relate to themselves
     Given connection close all sessions
     Given connection open data session for database: grakn

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-@ignore # TODO enable when rules can resolve negation, and we're not pathetically slow with `not { $x is $y };`
+@ignore # TODO enable when rules can resolve negation
 #noinspection CucumberUndefinedStep
 Feature: Concept Inequality Resolution
 


### PR DESCRIPTION
## What is the goal of this PR?
To make sure we cover the  original query that caused the failure in https://github.com/graknlabs/grakn/pull/6134, we add a test for a relation with a variable role and a fixed role, in a match query.

## What are the changes implemented in this PR?
* Add test case that tripped in the traversal engine, in a specific query plan where the starting point was the role player without the variable role `$x`
* slip in a cheeky test case for anonymous attributes with predicates, in `resolution/attribute-attachment.feature`