### PR TITLE
Test deleting nonexistent DB in Core and Cluster

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -149,5 +149,14 @@ Feature: Connection Database
       define person sub entity;
       """
 
-  Scenario: delete a nonexistent database throws an error
+
+  @ignore-cluster
+  Scenario: delete a nonexistent database throws an error in Core
     When connection delete database; throws exception: grakn
+
+
+  @ignore-core
+  Scenario: delete a nonexistent database is a no-op in Cluster
+    Given connection does not have database: grakn
+    When connection delete database; grakn
+    Then connection does not have database: grakn

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -158,5 +158,5 @@ Feature: Connection Database
   @ignore-core
   Scenario: delete a nonexistent database is a no-op in Cluster
     Given connection does not have database: grakn
-    When connection delete database; grakn
+    When connection delete database: grakn
     Then connection does not have database: grakn

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -150,13 +150,7 @@ Feature: Connection Database
       """
 
 
+  # TODO: re-enable in Cluster once fully fault-tolerant database deletion is implemented
   @ignore-cluster
-  Scenario: delete a nonexistent database throws an error in Core
+  Scenario: delete a nonexistent database throws an error
     When connection delete database; throws exception: grakn
-
-
-  @ignore-core
-  Scenario: delete a nonexistent database is a no-op in Cluster
-    Given connection does not have database: grakn
-    When connection delete database: grakn
-    Then connection does not have database: grakn


### PR DESCRIPTION
## What is the goal of this PR?

The behaviour of deleting a non-existent DB has now diverged between Grakn Core and Cluster; one throws, the other is a no-op. We added two tests for this, and each is suppressed when running against an inapplicable product.

## What are the changes implemented in this PR?

Test deleting nonexistent DB in both Core and Cluster
