### PR TITLE
Fix ignore tags broken by comments

### DIFF
--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -1134,7 +1134,8 @@ Feature: Graql Delete Query
   # COMPLEX PATTERNS #
   ####################
 
-  @ignore # TODO: enable once query planning has been optimised
+  # TODO: enable once query planning has been optimised
+  @ignore
   Scenario: deletion of a complex pattern
     Given connection close all sessions
     Given connection open schema session for database: grakn
@@ -1206,8 +1207,8 @@ Feature: Graql Delete Query
       | x             | n                    |
       | key:name:John | value:lastname:Smith |
 
-
-  @ignore # TODO: enable once query planning has been optimised
+  # TODO: enable once query planning has been optimised
+  @ignore
   Scenario: deleting everything in a complex pattern
     Given connection close all sessions
     Given connection open schema session for database: grakn

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -519,8 +519,8 @@ Feature: Graql Match Query
       | x                |
       | label:employment |
 
-
-  @ignore # TODO cannot currently query for schema with 'as'
+  # TODO cannot currently query for schema with 'as'
+  @ignore
   Scenario: 'relates' with 'as' matches relation types that override the specified roleplayer
     Given graql define
       """
@@ -772,8 +772,8 @@ Feature: Graql Match Query
       """
 
 
-
-  @ignore # TODO we can't query for rule anymore
+  # TODO we can't query for rule anymore
+  @ignore
   Scenario: an error is thrown when matching that a variable has a specific type, when that type is in fact a rule
     Given graql define
       """

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -443,8 +443,8 @@ Feature: Concept Inequality Resolution
     Then answer size in reasoned database is: 36
     Then materialised and reasoned databases are the same size
 
-
-  @ignore # TODO enable when we can resolve repeated concludables
+  # TODO enable when we can resolve repeated concludables
+  @ignore
   # TODO: re-enable once grakn#5821 is fixed (in some answers, $typeof_ax is 'base-attribute' which is incorrect)
   # TODO: re-enable all steps once implicit attribute variables are resolvable
   # TODO: migrate to concept-inequality.feature
@@ -509,7 +509,8 @@ Feature: Concept Inequality Resolution
     Then answer size in reasoned database is: 6
     Then materialised and reasoned databases are the same size
 
-  @ignore # TODO enable when we can resolve repeated concludables
+  # TODO enable when we can resolve repeated concludables
+  @ignore
   # TODO: re-enable once grakn#5821 is fixed
   # TODO: re-enable all steps once implicit attribute variables are resolvable
   # TODO: migrate to concept-inequality.feature

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -379,7 +379,8 @@ Feature: Value Predicate Resolution
     Then answer size in reasoned database is: 2
     Then materialised and reasoned databases are the same size
 
-  @ignore # TODO enable when we can resolve repeated concludables
+  # TODO enable when we can resolve repeated concludables
+  @ignore
   # TODO: re-enable all steps when fixed (#75)
   Scenario: inferred attributes can be matched by equality to an attribute that contains a specified string
     Given for each session, graql define
@@ -440,8 +441,8 @@ Feature: Value Predicate Resolution
     Then answer size in reasoned database is: 8
     Then materialised and reasoned databases are the same size
 
-
-  @ignore # TODO enable when we can resolve repeated concludables
+  # TODO enable when we can resolve repeated concludables
+  @ignore
   # TODO: re-enable all steps when fixed (#75)
   Scenario: inferred attributes can be matched by inequality to an attribute that contains a specified string
     Given for each session, graql define
@@ -678,8 +679,8 @@ Feature: Value Predicate Resolution
     Then answer size in reasoned database is: 2
     Then materialised and reasoned databases are the same size
 
-
-  @ignore # enable when we can resolve repeated concludable
+  # enable when we can resolve repeated concludable
+  @ignore
   # TODO: migrate to concept-inequality.feature
   Scenario: when using 'not { $x is $y; }' over attributes of the same value, the answers have distinct types
     Given for each session, graql define


### PR DESCRIPTION
## What is the goal of this PR?

Some Scenarios have ignore tags followed by a malformed comment. The Cucumber Gherkin reference states:
"Comments are only permitted at the start of a new line, anywhere in the feature file."
Cucumber does not give the below scenarios the ignore tag, as is presumably intended, and therefore those scenarios may be unintentionally executed.

## What are the changes implemented in this PR?

Move each comment to the preceding line.