### PR TITLE
Update for default-on reasoner

### DIFF
--- a/graql/reasoner/attribute-attachment.feature
+++ b/graql/reasoner/attribute-attachment.feature
@@ -88,7 +88,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person, has string-attribute $y;
@@ -96,7 +96,7 @@ Feature: Attribute Attachment Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa string-attribute;
@@ -142,7 +142,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has string-attribute $y;
@@ -188,7 +188,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has retailer 'Ocado';
@@ -200,7 +200,7 @@ Feature: Attribute Attachment Resolution
     Given connection open data sessions for databases:
       | reasoned     |
       | materialised |
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has retailer $r;
@@ -208,7 +208,7 @@ Feature: Attribute Attachment Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has retailer 'Tesco';
@@ -247,7 +247,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado';
@@ -281,7 +281,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has age > 20;
@@ -289,7 +289,7 @@ Feature: Attribute Attachment Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 0
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has age > 5;

--- a/graql/reasoner/compound-queries.feature
+++ b/graql/reasoner/compound-queries.feature
@@ -78,7 +78,7 @@ Feature: Compound Query Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/concept-inequality.feature
+++ b/graql/reasoner/concept-inequality.feature
@@ -129,7 +129,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (state: $s) isa holds;
@@ -137,7 +137,7 @@ Feature: Concept Inequality Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $s isa state, has name 's2';
@@ -149,7 +149,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (ball1: $x, ball2: $y) isa selection;
@@ -159,7 +159,7 @@ Feature: Concept Inequality Resolution
     # inferred: [aa, ac, bb, ca, cc]
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -171,7 +171,7 @@ Feature: Concept Inequality Resolution
     # inferred: [ac, ca]
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # verify that the answer pairs to the previous query have distinct names within each pair
     Then for graql query
       """
@@ -192,7 +192,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -203,7 +203,7 @@ Feature: Concept Inequality Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # verify answers are [ac, bc]
     Then for graql query
       """
@@ -232,7 +232,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -246,7 +246,7 @@ Feature: Concept Inequality Resolution
     #  cab, cac, cba, cbc, cca, ccb]
     Then answer size in reasoned database is: 18
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # verify that $y and $z always have distinct names
     Then for graql query
       """
@@ -280,7 +280,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -292,7 +292,7 @@ Feature: Concept Inequality Resolution
     Then answer size in reasoned database is: 18
     # verify that $y and $z always have distinct names
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -327,7 +327,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -340,7 +340,7 @@ Feature: Concept Inequality Resolution
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
     Then answer size in reasoned database is: 243
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -356,7 +356,7 @@ Feature: Concept Inequality Resolution
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
     Then answer size in reasoned database is: 108
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -394,7 +394,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -406,7 +406,7 @@ Feature: Concept Inequality Resolution
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
     Then answer size in reasoned database is: 81
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -421,7 +421,7 @@ Feature: Concept Inequality Resolution
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
     Then answer size in reasoned database is: 36
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -488,7 +488,7 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -509,7 +509,6 @@ Feature: Concept Inequality Resolution
     Then answer size in reasoned database is: 6
     Then materialised and reasoned databases are the same size
 
-  @ignore # TODO enable when we can resolve repeated concludables
   # TODO: re-enable once grakn#5821 is fixed
   # TODO: re-enable all steps once implicit attribute variables are resolvable
   # TODO: migrate to concept-inequality.feature
@@ -569,16 +568,17 @@ Feature: Concept Inequality Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
-        $x has base-attribute $value;
-        $y has base-attribute $unwantedValue;
+        $x has $value;
+        $y has $unwantedValue;
         not { $value is $unwantedValue; };
         $unwantedValue "Ocado";
         $value isa! $type;
         $unwantedValue isa! $type;
+        $type type base-attribute;
         not { $type is $unwantedType; };
         $unwantedType type string-attribute;
       get $x, $value, $type;

--- a/graql/reasoner/negation.feature
+++ b/graql/reasoner/negation.feature
@@ -89,14 +89,14 @@ Feature: Negation Resolution
       $e2 (employee: $x2, employer: $c) isa employment;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person;
       """
     Given answer size in reasoned database is: 5
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -127,14 +127,14 @@ Feature: Negation Resolution
       $e2 (employee: $x2, employer: $c) isa employment;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person;
       """
     Given answer size in reasoned database is: 5
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -162,14 +162,14 @@ Feature: Negation Resolution
       $x5 isa person;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa person;
       """
     Given answer size in reasoned database is: 5
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -197,14 +197,14 @@ Feature: Negation Resolution
       $x5 isa person;
       """
     Then for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa person;
       """
     Given answer size in reasoned database is: 5
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -230,7 +230,7 @@ Feature: Negation Resolution
       $z isa person;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -239,7 +239,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -263,7 +263,7 @@ Feature: Negation Resolution
       $w isa person, has name "Charlie";
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -272,7 +272,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $x has age $y;
@@ -306,7 +306,7 @@ Feature: Negation Resolution
       (friend: $d, friend: $z) isa friendship;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -321,7 +321,7 @@ Feature: Negation Resolution
     # zdcb, zdcd, zdzd
     Given answer size in reasoned database is: 24
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -333,7 +333,7 @@ Feature: Negation Resolution
     # Eliminates (cdzd, zdzd)
     Then answer size in reasoned database is: 22
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -371,7 +371,7 @@ Feature: Negation Resolution
       (friend: $d, friend: $z) isa friendship;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -385,7 +385,7 @@ Feature: Negation Resolution
     # zdc, zdz
     Given answer size in reasoned database is: 14
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -397,7 +397,7 @@ Feature: Negation Resolution
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then answer size in reasoned database is: 10
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -423,7 +423,7 @@ Feature: Negation Resolution
       (employee: $x, employer: $c) isa employment;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match ($r1: $x) isa employment;
@@ -435,7 +435,7 @@ Feature: Negation Resolution
     # employer | COM |
     Given answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -462,14 +462,14 @@ Feature: Negation Resolution
       $c isa company, has name "Pizza Express";
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has attribute $r;
       """
     Given answer size in reasoned database is: 8
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -480,7 +480,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -517,7 +517,7 @@ Feature: Negation Resolution
       """
     Given answer size in reasoned database is: 8
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -526,7 +526,7 @@ Feature: Negation Resolution
       """
     Given answer size in reasoned database is: 7
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -536,7 +536,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -582,7 +582,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -622,7 +622,7 @@ Feature: Negation Resolution
       (employee: $y, employer: $d) isa employment;
       """
     Then for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -663,7 +663,7 @@ Feature: Negation Resolution
       """
     # We match $x isa person and not {$x isa person; ...}; answers can still be returned because of the conjunction
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -718,7 +718,7 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -727,7 +727,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -805,7 +805,7 @@ Feature: Negation Resolution
       (from: $cc, to: $dd) isa link;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -814,7 +814,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -856,7 +856,7 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 20;
@@ -864,7 +864,7 @@ Feature: Negation Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has name "Not Ten", has age 10;
@@ -901,7 +901,7 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa person;
@@ -909,7 +909,7 @@ Feature: Negation Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person, has name "No Age";
@@ -962,14 +962,14 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa company;
       """
     Given answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -979,7 +979,7 @@ Feature: Negation Resolution
     # Should exclude both the company in France and the company with no country
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -989,7 +989,7 @@ Feature: Negation Resolution
       get $x;
       """
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1042,7 +1042,7 @@ Feature: Negation Resolution
       (country: $f, company: $c) isa company-country;
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1056,7 +1056,7 @@ Feature: Negation Resolution
       """
     Then answer size in reasoned database is: 3
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1166,7 +1166,7 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
@@ -1249,7 +1249,7 @@ Feature: Negation Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role-3: $x, role-4: $y) isa relation-4;
@@ -1334,7 +1334,7 @@ Feature: Negation Resolution
       """
     # Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
     """
       match
@@ -1344,7 +1344,7 @@ Feature: Negation Resolution
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then answer size in reasoned database is: 5
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # TODO: Check again if we correctly mean '$y isa node' when we enable this test
     Then answer set is equivalent for graql query
       """

--- a/graql/reasoner/recursion.feature
+++ b/graql/reasoner/recursion.feature
@@ -113,7 +113,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa big-location-hierarchy;
@@ -192,7 +192,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -265,7 +265,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3;
@@ -274,7 +274,7 @@ Feature: Recursion Resolution
     # Each of the two material relation1 instances should infer a single relation3 via 1-to-2 and 2-to-3
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role21: $x, role22: $y) isa relation2;
@@ -322,7 +322,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa dream; limit 10;
@@ -424,7 +424,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $p isa pair, has name 'ff';
@@ -432,7 +432,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 16
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $p isa pair;
@@ -531,7 +531,7 @@ Feature: Recursion Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -544,7 +544,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -619,7 +619,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -631,7 +631,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -649,7 +649,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -664,7 +664,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 10
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -684,7 +684,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 20
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -771,7 +771,7 @@ Feature: Recursion Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -785,7 +785,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: read
     Then all answers are correct in reasoned database
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -794,7 +794,7 @@ Feature: Recursion Resolution
       get $Y;
       """
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     And answer set is equivalent for graql query
       """
       match
@@ -803,7 +803,7 @@ Feature: Recursion Resolution
       get $Y;
       """
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -813,10 +813,10 @@ Feature: Recursion Resolution
       """
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then all answers are correct in reasoned database
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -825,7 +825,7 @@ Feature: Recursion Resolution
       get $X;
       """
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     And answer set is equivalent for graql query
       """
       match
@@ -904,7 +904,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -915,7 +915,7 @@ Feature: Recursion Resolution
     Then answer size in reasoned database is: 2
     Then all answers are correct in reasoned database
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -993,7 +993,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1004,7 +1004,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $x has index 'a2';
@@ -1097,7 +1097,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa reachable;
@@ -1105,7 +1105,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 7
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1182,7 +1182,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1193,7 +1193,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 4
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1271,7 +1271,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1282,7 +1282,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 3
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1391,7 +1391,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1402,7 +1402,7 @@ Feature: Recursion Resolution
     Then answer size in reasoned database is: 3
     Then all answers are correct in reasoned database
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1411,7 +1411,7 @@ Feature: Recursion Resolution
       get $y;
       """
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (from: $x, to: $y) isa RevSG;
@@ -1419,7 +1419,7 @@ Feature: Recursion Resolution
     Then answer size in reasoned database is: 11
     Then all answers are correct in reasoned database
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -1598,7 +1598,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1609,7 +1609,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 5
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa $t; { $t type a-entity; } or { $t type end; }; get $y;
@@ -1814,7 +1814,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1825,7 +1825,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 60
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa b-entity;
@@ -1976,7 +1976,7 @@ Feature: Recursion Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1987,7 +1987,7 @@ Feature: Recursion Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 25
     Given for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match $y isa a-entity;

--- a/graql/reasoner/relation-inference.feature
+++ b/graql/reasoner/relation-inference.feature
@@ -94,7 +94,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -104,7 +104,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
 
 
   Scenario: a relation can be inferred based on an attribute ownership
@@ -133,7 +133,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -143,7 +143,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -184,7 +184,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -230,7 +230,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -277,7 +277,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $r isa friendship;
@@ -321,7 +321,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($x, $y) isa friendship;
@@ -360,7 +360,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -396,7 +396,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -434,7 +434,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (employee: $x, employer: $x) isa employment;
@@ -503,7 +503,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $x) isa coworkers;
@@ -517,7 +517,7 @@ Feature: Relation Inference Resolution
     # therefore (r1,r1) is a reflexive coworker relation. So the answers are [p] and [r1].
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (coworker: $x, coworker: $y) isa coworkers;
@@ -570,7 +570,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa location-hierarchy;
@@ -614,7 +614,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
@@ -685,7 +685,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
@@ -726,7 +726,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment;
@@ -762,7 +762,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (employee: $x) isa employment;
@@ -801,7 +801,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
@@ -809,7 +809,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -857,7 +857,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -869,7 +869,7 @@ Feature: Relation Inference Resolution
     # (a,a), (b,b), (c,c)
     Then answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -882,7 +882,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match
@@ -929,7 +929,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -976,7 +976,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -987,7 +987,7 @@ Feature: Relation Inference Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1045,7 +1045,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match ($a, $b) isa relation;
@@ -1055,7 +1055,7 @@ Feature: Relation Inference Resolution
     # because the query is only interested in the related concepts, not in the relation instances themselves
     Then answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then answer set is equivalent for graql query
       """
       match ($a, $b);
@@ -1095,7 +1095,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -1171,7 +1171,7 @@ Feature: Relation Inference Resolution
     Given for each session, open transactions of type: write
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($x) isa derivedRelation;
@@ -1179,7 +1179,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($x) isa! derivedRelation;
@@ -1187,7 +1187,7 @@ Feature: Relation Inference Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($x) isa directDerivedRelation;

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -338,7 +338,8 @@ Feature: Resolution Test Framework
     Then all answers are correct in reasoned database
     Then materialised and reasoned databases are the same size
 
-
+  # TODO: Reenable when negation in rules is permitted
+  @ignore
   Scenario: a rule containing a negation
     Given for each session, graql define
       """

--- a/graql/reasoner/resolution-test-framework.feature
+++ b/graql/reasoner/resolution-test-framework.feature
@@ -58,7 +58,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $co has name $n;
@@ -107,7 +107,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $co has is-liable $l;
@@ -162,7 +162,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -225,7 +225,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $lh (superior: $continent, subordinate: $area) isa location-hierarchy;
@@ -282,7 +282,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman;
@@ -328,7 +328,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $com isa company;
@@ -380,7 +380,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true;
@@ -427,7 +427,7 @@ Feature: Resolution Test Framework
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };

--- a/graql/reasoner/rule-interaction.feature
+++ b/graql/reasoner/rule-interaction.feature
@@ -116,7 +116,7 @@ Feature: Rule Interaction Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person, has name $n, has tag "P";
@@ -177,7 +177,7 @@ Feature: Rule Interaction Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa person, has name 'tracey';

--- a/graql/reasoner/schema-queries.feature
+++ b/graql/reasoner/schema-queries.feature
@@ -96,14 +96,14 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa entity;
       """
     Given answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -111,14 +111,14 @@ Feature: Schema Query Resolution (Variable Types)
     # (xx, yy, zz, xy, xz, yz)
     Given answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa attribute;
       """
     Given answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x isa $type;
@@ -160,7 +160,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match ($u, $v) isa relation;
@@ -168,7 +168,7 @@ Feature: Schema Query Resolution (Variable Types)
     # (xx, yy, zz, xy, xz, yz, yx, zx, zy)
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($u, $v) isa $type;
@@ -229,7 +229,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -237,7 +237,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -284,7 +284,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -292,7 +292,7 @@ Feature: Schema Query Resolution (Variable Types)
     # 3 friendships, 3 employments
     Given answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -355,7 +355,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match $x isa relation;
@@ -363,7 +363,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 6
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -413,7 +413,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (employee: $x, employer: $y) isa employment;
@@ -421,7 +421,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 3
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -432,7 +432,7 @@ Feature: Schema Query Resolution (Variable Types)
     # 3 colonels * 5 supertypes of colonel (colonel, military-person, person, entity, thing)
     Then answer size in reasoned database is: 15
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -481,7 +481,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -499,7 +499,7 @@ Feature: Schema Query Resolution (Variable Types)
     # Query returns {ab,ac,ad,bc,bd,cd} and each of them with the variables flipped
     Then answer size in reasoned database is: 12
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/type-hierarchy.feature
+++ b/graql/reasoner/type-hierarchy.feature
@@ -82,7 +82,7 @@ Feature: Type Hierarchy Resolution
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -94,7 +94,7 @@ Feature: Type Hierarchy Resolution
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -106,7 +106,7 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -118,7 +118,7 @@ Feature: Type Hierarchy Resolution
     # Answer is (actor:$x, writer:$v) ONLY
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -130,7 +130,7 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -142,7 +142,7 @@ Feature: Type Hierarchy Resolution
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -196,7 +196,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # Matching a sibling of the actual role
     Then for graql query
       """
@@ -204,7 +204,7 @@ Feature: Type Hierarchy Resolution
       """
     Then answer size in reasoned database is: 0
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # Matching two siblings when only one is present
     Then for graql query
       """
@@ -260,7 +260,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # sub-roles, super-relation
     Then for graql query
       """
@@ -317,7 +317,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # super-roles, sub-relation
     Then for graql query
       """
@@ -374,7 +374,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # super-roles, super-relation
     Then for graql query
       """
@@ -447,7 +447,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -459,7 +459,7 @@ Feature: Type Hierarchy Resolution
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -471,7 +471,7 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -483,7 +483,7 @@ Feature: Type Hierarchy Resolution
     # Answer is (actor:$x, writer:$v) ONLY
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -495,7 +495,7 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -507,7 +507,7 @@ Feature: Type Hierarchy Resolution
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -567,7 +567,7 @@ Feature: Type Hierarchy Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (home-owner: $x, resident: $y) isa residence;
@@ -575,7 +575,7 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match

--- a/graql/reasoner/value-predicate.feature
+++ b/graql/reasoner/value-predicate.feature
@@ -84,7 +84,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match $x has is-old $r;
@@ -119,7 +119,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -164,7 +164,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -211,7 +211,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -267,7 +267,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -316,7 +316,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -368,7 +368,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -418,7 +418,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -480,7 +480,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -544,7 +544,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -557,7 +557,7 @@ Feature: Value Predicate Resolution
     # Tango | Tesco |
     Given answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -602,7 +602,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match
@@ -615,7 +615,7 @@ Feature: Value Predicate Resolution
     # Tango | Ocado |
     Given answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -661,7 +661,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -714,7 +714,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -800,7 +800,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -810,7 +810,7 @@ Feature: Value Predicate Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 2
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -820,7 +820,7 @@ Feature: Value Predicate Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -830,7 +830,7 @@ Feature: Value Predicate Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -840,7 +840,7 @@ Feature: Value Predicate Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 1
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -911,7 +911,7 @@ Feature: Value Predicate Resolution
       """
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession;

--- a/graql/reasoner/variable-roles.feature
+++ b/graql/reasoner/variable-roles.feature
@@ -152,7 +152,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -160,7 +160,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -174,7 +174,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable role bound with 'type' does not modify the answer size
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role1: $a, $r1: $b) isa binary-base;
@@ -182,7 +182,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 18
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -199,7 +199,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -207,7 +207,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -221,7 +221,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -229,7 +229,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -246,7 +246,7 @@ Feature: Variable Role Resolution
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role: $a, $r1: $b) isa binary-base;
@@ -254,7 +254,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Then answer size in reasoned database is: 27
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -271,7 +271,7 @@ Feature: Variable Role Resolution
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -283,7 +283,7 @@ Feature: Variable Role Resolution
     Then all answers are correct in reasoned database
     Then answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     # This query is equivalent to the one above
     Then for graql query
       """
@@ -299,7 +299,7 @@ Feature: Variable Role Resolution
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Given for graql query
       """
       match (role1: $a, role2: $b) isa binary-base;
@@ -307,7 +307,7 @@ Feature: Variable Role Resolution
     Given all answers are correct in reasoned database
     Given answer size in reasoned database is: 9
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($r1: $a, $r2: $b) isa binary-base;
@@ -374,7 +374,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -385,7 +385,7 @@ Feature: Variable Role Resolution
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
     Then answer size in reasoned database is: 63
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
@@ -394,7 +394,7 @@ Feature: Variable Role Resolution
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then answer size in reasoned database is: 189
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
@@ -421,7 +421,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -432,7 +432,7 @@ Feature: Variable Role Resolution
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
     Then answer size in reasoned database is: 918
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
@@ -441,7 +441,7 @@ Feature: Variable Role Resolution
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then answer size in reasoned database is: 2754
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
@@ -467,7 +467,7 @@ Feature: Variable Role Resolution
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
     Then materialised database is completed
     Given for each session, transaction commits
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match
@@ -478,7 +478,7 @@ Feature: Variable Role Resolution
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
     Then answer size in reasoned database is: 272
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
@@ -487,7 +487,7 @@ Feature: Variable Role Resolution
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
     Then answer size in reasoned database is: 544
     Then for each session, transaction closes
-    Given for each session, open transactions with reasoning of type: read
+    Given for each session, open transactions of type: read
     Then for graql query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;


### PR DESCRIPTION
## What is the goal of this PR?

While making reasoner on by default in grakn core we remove the need for some unnecessary step definitions that enabled reasoner manually for reasoner's scenarios.

## What are the changes implemented in this PR?

- Fix one test and unignore it.
- Use the generic transaction steps rather than reasoning-specific ones (which have been removed in Grakn Core).