### PR TITLE
Add scenario to test negation on a filtered out variable

### DIFF
--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1945,7 +1945,7 @@ Feature: Graql Match Query
       """
       insert
       $x isa person, has name "Jeff", has ref 0;
-      $x isa person, has name "Jenny", has ref 1;
+      $y isa person, has name "Jenny", has ref 1;
       """
     Given transaction commits
 

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1937,6 +1937,27 @@ Feature: Graql Match Query
       | key:ref:1 |
 
 
+  Scenario: negations can be applied to filtered variables
+    Given connection close all sessions
+    Given connection open data session for database: grakn
+    Given session opens transaction of type: write
+    Given graql insert
+      """
+      insert
+      $x isa person, has name "Jeff", has ref 0;
+      $x isa person, has name "Jenny", has ref 1;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of graql match
+      """
+      match $x isa person, has name $a; not { $a = "Jeff"; }; get $x;
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | key:ref:1 |
+
   ##################
   # VARIABLE TYPES #
   ##################


### PR DESCRIPTION
## What is the goal of this PR?
Add a test to ensure that filtering out variables still allows negations to operate correctly.

## What are the changes implemented in this PR?
* add scenario using a `get` which only contains variable that are not mentioned in the negation
