### PR TITLE
Unignore tests that should now pass

### DIFF
--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -1752,11 +1752,11 @@ Feature: Graql Define Query
   Scenario: changing a concrete type to abstract throws on commit if it has a concrete supertype
 
   @ignore
-  # TODO: re-enable when rules cannot infer abstract relations
+  # TODO: re-enable when rules are indexed
   Scenario: changing a concrete relation type to abstract throws on commit if it appears in the conclusion of any rule
 
   @ignore
-  # TODO: re-enable when rules cannot infer abstract attributes
+  # TODO: re-enable when rules are indexed
   Scenario: changing a concrete attribute type to abstract throws on commit if it appears in the conclusion of any rule
 
   ######################

--- a/graql/language/delete.feature
+++ b/graql/language/delete.feature
@@ -1129,13 +1129,10 @@ Feature: Graql Delete Query
       """
 
 
-
   ####################
   # COMPLEX PATTERNS #
   ####################
 
-  # TODO: enable once query planning has been optimised
-  @ignore
   Scenario: deletion of a complex pattern
     Given connection close all sessions
     Given connection open schema session for database: grakn
@@ -1207,8 +1204,7 @@ Feature: Graql Delete Query
       | x             | n                    |
       | key:name:John | value:lastname:Smith |
 
-  # TODO: enable once query planning has been optimised
-  @ignore
+
   Scenario: deleting everything in a complex pattern
     Given connection close all sessions
     Given connection open schema session for database: grakn
@@ -1295,7 +1291,6 @@ Feature: Graql Delete Query
     Then transaction commits; throws exception
 
   @ignore
-  # TODO: re-enable when deleting an attribute instance that is owned as a has throws @key an error
   Scenario: deleting an attribute instance that is owned as a has throws @key an error
     Given graql insert
       """

--- a/graql/language/insert.feature
+++ b/graql/language/insert.feature
@@ -647,7 +647,8 @@ Feature: Graql Insert Query
       | a                     |
       | value:tenure-days:365 |
 
-  #TODO: Reenable when rules actually do something
+
+  #TODO: Reenable when reasoning can run in a write transaction
   @ignore
   Scenario: an attribute ownership currently inferred by a rule can be explicitly inserted
     Given connection close all sessions
@@ -1852,7 +1853,7 @@ Feature: Graql Insert Query
   #####################################
 
   # Note: These tests have been placed here because Resolution Testing was not built to handle these kinds of cases
-  #TODO: Reenable when rules actually do something
+  #TODO: Reenable when reasoning can run in a write transaction
   @ignore
   Scenario: when inserting a thing that has inferred concepts, those concepts are not automatically materialised
     Given connection close all sessions
@@ -1908,7 +1909,7 @@ Feature: Graql Insert Query
     # If the name 'Ganesh' had been materialised, then it would still exist in the knowledge graph.
     Then answer size is: 0
 
-  #TODO: Reenable when rules actually do something
+  #TODO: Reenable when reasoning can run in a write transaction
   @ignore
   Scenario: when inserting a thing with an inferred attribute ownership, the ownership is not automatically persisted
     Given connection close all sessions
@@ -2073,7 +2074,7 @@ Feature: Graql Insert Query
       | x                 | y              |
       | value:name:Ganesh | value:letter:G |
 
-  #TODO: Reenable when rules actually do something
+  #TODO: Reenable when reasoning can run in a write transaction
   @ignore
   Scenario: when inserting things connected to an inferred relation, the inferred relation gets materialised
     Given connection close all sessions
@@ -2161,7 +2162,7 @@ Feature: Graql Insert Query
     # And the inserted relation still exists too
     Then answer size is: 1
 
-  #TODO: Reenable when rules actually do something
+  #TODO: Reenable when reasoning can run in a write transaction
   @ignore
   Scenario: when inserting things connected to a chain of inferred concepts, the whole chain is materialised
     Given connection close all sessions

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1092,16 +1092,12 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
 
-
-  # TODO: fix - query does not throw exception, but it should
-  @ignore
   Scenario: an error is thrown when matching an entity type as if it were a relation type
     Then graql match; throws exception
       """
       match ($x) isa person;
       """
     Then session transaction is open: false
-
 
 
   Scenario: an error is thrown when matching a non-existent type label as if it were a relation type
@@ -1112,14 +1108,12 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
 
-
   Scenario: when matching a role type that doesn't exist, an error is thrown
     Then graql match; throws exception
       """
       match (rolein-rolein-rolein: $rolein) isa relation;
       """
     Then session transaction is open: false
-
 
 
   Scenario: when matching a role in a relation type that doesn't have that role, an error is thrown
@@ -1130,9 +1124,6 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
 
-
-  # TODO: re-enable when fixed (it doesn't throw)
-  @ignore
   Scenario: when matching a roleplayer in a relation that can't actually play that role, an error is thrown
     When graql match; throws exception
       """
@@ -1556,8 +1547,6 @@ Feature: Graql Match Query
       | key:ref:0 |
 
 
-  # TODO: re-enable when fixed (it doesn't throw)
-  @ignore
   Scenario: an error is thrown when matching by attribute ownership, when the owned thing is actually an entity
     Then graql match; throws exception
       """
@@ -1566,16 +1555,12 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
 
-
-  # TODO: re-enable when fixed (it doesn't throw)
-  @ignore
-  Scenario: when matching by an attribute ownership, if the owner can't actually own it, an empty result is returned
+  Scenario: exception is thrown when matching by an attribute ownership, if the owner can't actually own it0
     Then graql match; throws exception
       """
       match $x isa company, has age $n;
       """
     Then session transaction is open: false
-
 
 
   Scenario: an error is thrown when matching by attribute ownership, when the owned type label doesn't exist

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1555,7 +1555,7 @@ Feature: Graql Match Query
     Then session transaction is open: false
 
 
-  Scenario: exception is thrown when matching by an attribute ownership, if the owner can't actually own it0
+  Scenario: exception is thrown when matching by an attribute ownership, if the owner can't actually own it
     Then graql match; throws exception
       """
       match $x isa company, has age $n;

--- a/graql/language/rule-validation.feature
+++ b/graql/language/rule-validation.feature
@@ -108,7 +108,7 @@ Feature: Graql Rule Validation
     Then graql define; throws exception
       """
       define
-      
+
       rule robert: when {
         $p has name "Robert";
       } then {

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -223,8 +223,6 @@ Feature: Graql Undefine Query
       """
     Then answer size is: 0
 
-  #TODO: Reenable when deletion works
-  @ignore
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
     Given get answers of graql match
       """
@@ -438,8 +436,6 @@ Feature: Graql Undefine Query
       """
 
 
-  #TODO: Reenable when deletion works
-  @ignore
   Scenario: all existing instances of a relation type must be deleted in order to undefine it
     Given get answers of graql match
       """
@@ -568,7 +564,7 @@ Feature: Graql Undefine Query
       """
     Then answer size is: 0
 
-  #TODO: Reenable when deletion works
+  #TODO: test is not working
   @ignore
   Scenario: after removing a role from a relation type, relation instances can no longer be created with that role
     Given connection close all sessions
@@ -753,8 +749,6 @@ Feature: Graql Undefine Query
   # PLAYABLE ROLES ('PLAYS') #
   ############################
 
-  #TODO: Reenable when deletion works
-  @ignore
   Scenario: after undefining a playable role from a type, the type can no longer play the role
     Given connection close all sessions
     Given connection open data session for database: grakn
@@ -1035,8 +1029,6 @@ Feature: Graql Undefine Query
       """
 
 
-  #TODO: Reenable when deletion works
-  @ignore
   Scenario: all existing instances of an attribute type must be deleted in order to undefine it
     Given get answers of graql match
       """
@@ -1285,8 +1277,6 @@ Feature: Graql Undefine Query
     When session opens transaction of type: read
     Then rules do not contain: a-rule
 
-  #TODO: Reenable when rules actually do something
-  @ignore
   Scenario: after undefining a rule, concepts previously inferred by that rule are no longer inferred
     Given graql define
       """
@@ -1337,8 +1327,8 @@ Feature: Graql Undefine Query
       """
     Then answer size is: 0
 
-  #TODO: Reenable when rules actually do something
-  @ignore
+
+  @ignore # TODO enable when we can do reasoning in a schema write transaction
   Scenario: when undefining a rule, concepts inferred by that rule can still be retrieved until the next commit
     Given graql define
       """

--- a/graql/language/undefine.feature
+++ b/graql/language/undefine.feature
@@ -77,7 +77,6 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: a sub-entity type can be removed using 'sub' with its direct supertype, and its parent is preserved
     Given graql define
       """
@@ -155,7 +154,6 @@ Feature: Graql Undefine Query
       """
       undefine person sub entity;
       """
-
 
 
   Scenario: removing a playable role from a super entity type also removes it from its subtypes
@@ -616,7 +614,6 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: removing all roles from a relation type without undefining the relation type throws on commit
     When graql undefine
       """
@@ -625,7 +622,6 @@ Feature: Graql Undefine Query
       employment relates employer;
       """
     Then transaction commits; throws exception
-
 
 
   Scenario: undefining a role type automatically detaches any possible roleplayers
@@ -681,7 +677,6 @@ Feature: Graql Undefine Query
       """
       undefine employment relates employer;
       """
-
 
 
   Scenario: a role that is not played in any existing instance of its relation type can be safely removed
@@ -797,7 +792,6 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: undefining a playable role that was not actually playable to begin with throws
     Given get answers of graql match
       """
@@ -810,7 +804,6 @@ Feature: Graql Undefine Query
       """
       undefine person plays employment:employer;
       """
-
 
 
   Scenario: removing a playable role throws an error if it is played by existing instances
@@ -832,7 +825,6 @@ Feature: Graql Undefine Query
       """
       undefine person plays employment:employee;
       """
-
 
 
   ###################
@@ -1125,7 +1117,6 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: attempting to undefine an attribute ownership inherited from a parent throws
     Given graql define
       """
@@ -1138,7 +1129,6 @@ Feature: Graql Undefine Query
       """
       undefine child owns name;
       """
-
 
 
   Scenario: undefining a key ownership removes it
@@ -1163,13 +1153,11 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: writing '@key' when undefining an attribute ownership is not allowed
     Then graql undefine; throws exception
       """
       undefine person owns name @key;
       """
-
 
 
   Scenario: when a type can own an attribute, but none of its instances actually do, the ownership can be undefined
@@ -1227,7 +1215,6 @@ Feature: Graql Undefine Query
       """
 
 
-
   Scenario: undefining a key ownership throws an error if it is owned by existing instances
     Given connection close all sessions
     Given connection open data session for database: grakn
@@ -1245,7 +1232,6 @@ Feature: Graql Undefine Query
       """
       undefine person owns email;
       """
-
 
 
   #########
@@ -1328,7 +1314,8 @@ Feature: Graql Undefine Query
     Then answer size is: 0
 
 
-  @ignore # TODO enable when we can do reasoning in a schema write transaction
+  # TODO enable when we can do reasoning in a schema write transaction
+  @ignore
   Scenario: when undefining a rule, concepts inferred by that rule can still be retrieved until the next commit
     Given graql define
       """


### PR DESCRIPTION
## What is the goal of this PR?
We unignore tests that now pas CI in Grakn Core, based on the TODOs noted by the tests themselves.

## What are the changes implemented in this PR?
* Unignore a load of tests in `graql/language`, which were disable because of missing delete features, or missing reasoning