### PR TITLE
Add match scenario that fails due to traversal bug

### DIFF
--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1222,6 +1222,42 @@ Feature: Graql Match Query
     Then answer size is: 4
 
 
+  Scenario: When some relations do not satisfy the query, the correct ones are still found
+    Given graql define
+      """
+      define
+      car sub entity, plays ownership:owned;
+      person plays ownership:owner;
+      company plays ownership:owner;
+      ownership sub relation, relates owned, relates owner, owns is-insured;
+      is-insured sub attribute, value boolean;"
+      """
+    Given transaction commits
+    Given connection close all sessions
+    Given connection open data session for database: grakn
+    Given session opens transaction of type: write
+    Given graql insert
+      """
+      insert
+      (owned: $c1, owner: $company) isa ownership, has is-insured true;
+      $c1 isa car; $company isa company;
+      """
+    Given transaction commits
+    Given session opens transaction of type: write
+    Given graql insert
+      """
+      insert
+      (owned: $c2, owner: $person) isa ownership, has is-insured true;
+      $c2 isa car; $person isa person;
+      """
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of graql match
+    """
+    match $r (owner: $x) isa ownership, has is-insured true; $x isa person;
+    """
+    Then answer size is: 1
+
   ##############
   # ATTRIBUTES #
   ##############

--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -1226,11 +1226,11 @@ Feature: Graql Match Query
     Given graql define
       """
       define
-      car sub entity, plays ownership:owned;
+      car sub entity, plays ownership:owned, owns ref @key;
       person plays ownership:owner;
       company plays ownership:owner;
       ownership sub relation, relates owned, relates owner, owns is-insured;
-      is-insured sub attribute, value boolean;"
+      is-insured sub attribute, value boolean;
       """
     Given transaction commits
     Given connection close all sessions
@@ -1240,7 +1240,7 @@ Feature: Graql Match Query
       """
       insert
       (owned: $c1, owner: $company) isa ownership, has is-insured true;
-      $c1 isa car; $company isa company;
+      $c1 isa car, has ref 0; $company isa company, has ref 1;
       """
     Given transaction commits
     Given session opens transaction of type: write
@@ -1248,7 +1248,7 @@ Feature: Graql Match Query
       """
       insert
       (owned: $c2, owner: $person) isa ownership, has is-insured true;
-      $c2 isa car; $person isa person;
+      $c2 isa car, has ref 2; $person isa person, has ref 3;
       """
     Given transaction commits
     Given session opens transaction of type: read


### PR DESCRIPTION
## What is the goal of this PR?
To add a test for the case fixed by https://github.com/graknlabs/grakn/pull/6287  - adding a test in which some relations fail and others satisfy the query, but we should still find the satisfying one.

## What are the changes implemented in this PR?
* Add test that should find the one satisifying relation
* note: we insert the relations separately in two transactions to force the rocks iterators to look them up in a particular order later
