### PR TITLE
Add scenario to ensure relation subtypes can introduce new roles

### DIFF
--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -521,6 +521,26 @@ Feature: Graql Define Query
       """
 
 
+  Scenario: relation subtypes can have roles that their supertypes don't have
+    Given graql define
+      """
+      define
+      plane sub entity, plays preferred-plane;
+      pilot-employment sub employment, relates pilot as employee, relates preferred-plane;
+      person plays pilot;
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x relates preferred-plane; get;
+      """
+    Then concept identifiers are
+      |     | check | value            |
+      | PIE | label | pilot-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | PIE |
+
 
   Scenario: types should be able to define roles they play with an override
     Then graql define

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -534,7 +534,7 @@ Feature: Graql Define Query
     Given session opens transaction of type: read
     When get answers of graql match
       """
-      match $x relates preferred-plane; get;
+      match $x relates preferred-plane;
       """
     Then uniquely identify answer concepts
       | x                       |

--- a/graql/language/define.feature
+++ b/graql/language/define.feature
@@ -525,21 +525,20 @@ Feature: Graql Define Query
     Given graql define
       """
       define
-      plane sub entity, plays preferred-plane;
+      plane sub entity, plays pilot-employment:preferred-plane;
       pilot-employment sub employment, relates pilot as employee, relates preferred-plane;
-      person plays pilot;
+      person plays pilot-employment:pilot;
       """
-    Given the integrity is validated
-    When get answers of graql query
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of graql match
       """
       match $x relates preferred-plane; get;
       """
-    Then concept identifiers are
-      |     | check | value            |
-      | PIE | label | pilot-employment |
     Then uniquely identify answer concepts
-      | x   |
-      | PIE |
+      | x                       |
+      | label:pilot-employment  |
 
 
   Scenario: types should be able to define roles they play with an override


### PR DESCRIPTION
## What is the goal of this PR?

Add a scenario to ensure relation subtypes can introduce new roles that their parents don't have.

## What are the changes implemented in this PR?

- Adds a new BDD scenario to `define.feature`

Addresses https://github.com/graknlabs/grakn/issues/5553