### PR TITLE
Make match-by-key ownership test more precise

### DIFF
--- a/graql/language/match.feature
+++ b/graql/language/match.feature
@@ -466,6 +466,7 @@ Feature: Graql Match Query
       define
       breed sub attribute, value string;
       dog sub entity, owns breed @key;
+      kennel sub entity, owns breed;
       """
     Given transaction commits
 


### PR DESCRIPTION
## What is the goal of this PR?

Our `match $x owns $y @key` test was not terribly informative - it showed that we were able to match attributes even with `@key` specified, but didn't necessarily confirm that it wasn't also matching attributes that weren't owned as keys. So we updated it to improve its precision.

## What are the changes implemented in this PR?

Make 'match $x owns $y @key' test more precise
